### PR TITLE
fixing issue #22 : MDX request can now be directly submitted

### DIFF
--- a/app/submitQuery/page.tsx
+++ b/app/submitQuery/page.tsx
@@ -20,8 +20,11 @@ export default function SubmitQueryPage(): ReactElement {
     try {
       setError(null);
       setResponse(null);
+
+      const payload = { mdx: values.text };
+
       // POST using Axios
-      const res = await axios.post(values.url, values.text, {
+      const res = await axios.post(values.url, payload, {
         auth: {
           username: values.username,
           password: values.password,


### PR DESCRIPTION
Fixing issue #22 
Fix: the user can now directly submit his MDX query, for example: SELECT ...
Before, he had to enter {"mdx":"SELECT ..."}. This syntax does not work anymore.

**How to test:**
- Launch the app with ```yarn dev```
- Reach localhost:3000
- Check that submitting a direct MDX request works correctly

