### PR TITLE
Fix issue #24: Query Plan type

### DIFF
--- a/app/submit-query/page.tsx
+++ b/app/submit-query/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { QueryPlan } from "@/lib";
 import axios from "axios";
 import { Formik, Form, Field } from "formik";
 import { useState, ReactElement } from "react";
@@ -7,7 +8,7 @@ const DEFAULT_URL =
   "https://activepivot-ranch.activeviam.com:6100/activeviam/pivot/rest/v9/cube/query/mdx/queryplan";
 
 export default function SubmitQueryPage(): ReactElement {
-  const [response, setResponse] = useState<string | null>(null);
+  const [response, setResponse] = useState<QueryPlan | null>();
   const [error, setError] = useState<string | null>(null);
 
   // Formular submission
@@ -24,7 +25,7 @@ export default function SubmitQueryPage(): ReactElement {
       const payload = { mdx: values.text };
 
       // POST using Axios
-      const res = await axios.post(values.url, payload, {
+      const res = await axios.post<QueryPlan>(values.url, payload, {
         auth: {
           username: values.username,
           password: values.password,
@@ -34,7 +35,7 @@ export default function SubmitQueryPage(): ReactElement {
         },
       });
 
-      setResponse(JSON.stringify(res.data, null, 2));
+      setResponse(res.data);
     } catch (err) {
       setError("Error: " + String(err));
     }
@@ -104,14 +105,18 @@ export default function SubmitQueryPage(): ReactElement {
             <div className="flex justify-between items-center mb-2">
               <h2 className="font-medium text-lg">Server reply:</h2>
               <button
-                onClick={() => navigator.clipboard.writeText(response)}
+                onClick={() =>
+                  navigator.clipboard.writeText(
+                    JSON.stringify(response, null, 2),
+                  )
+                }
                 className="text-sm text-blue-600 hover:text-blue-800 underline dark:text-blue-400 dark:hover:text-blue-300"
               >
                 Copy response
               </button>
             </div>
             <pre className="whitespace-pre-wrap text-sm bg-white p-2 rounded-md text-gray-800 dark:bg-gray-900 dark:text-gray-100">
-              {response}
+              {JSON.stringify(response, null, 2)}
             </pre>
           </div>
         )}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,0 +1,1 @@
+export * from "./queryPlan";

--- a/lib/queryPlan.ts
+++ b/lib/queryPlan.ts
@@ -1,15 +1,39 @@
-type EmptyObject = Record<string, never>; // Not a true type but it seems some objects are really meant to be empty
+// A lot of the types here are inferred from the JSON response of the query plan endpoint
+// I think quite a few `string` types could be enums, but I'm not sure what the possible values are
+
+type Context = {
+  IBranch: string;
+  ISubCubeProperties: string;
+  IAsOfEpoch: string;
+  IQueryMonitoring: string;
+  IQueriesResultLimit: string;
+};
+
+type PlanInfo = {
+  pivotType: string;
+  pivotId: string;
+  epoch: string;
+  branch: string;
+  retrieverType: string;
+  mdxPass: string;
+  contextValues: Context;
+  rangeSharing: number;
+  missedPrefetchBehavior: string;
+  aggregatesCache: string;
+  globalTimings: Record<string, number>;
+  continuous: boolean;
+};
 
 type Location = {
   dimension: string;
   hierarchy: string;
   level: string[];
-  path: EmptyObject[];
+  path: string[];
 };
 
 type TimingInfo = Record<string, number[]>;
 
-type Retrieval = {
+type AggregateRetrieval = {
   retrievalId: number;
   partialProviderName: string;
   type: string;
@@ -51,8 +75,8 @@ type QuerySummary = {
 };
 
 export type QueryPlan = {
-  planInfo: EmptyObject;
-  aggregateRetrievals: Retrieval[];
+  planInfo: PlanInfo;
+  aggregateRetrievals: AggregateRetrieval[];
   dependencies: Dependencies;
   databaseRetrievals: DatabaseRetrieval[];
   databaseDependencies: Dependencies;

--- a/lib/queryPlan.ts
+++ b/lib/queryPlan.ts
@@ -1,0 +1,61 @@
+type EmptyObject = Record<string, never>; // Not a true type but it seems some objects are really meant to be empty
+
+type Location = {
+  dimension: string;
+  hierarchy: string;
+  level: string[];
+  path: EmptyObject[];
+};
+
+type TimingInfo = Record<string, number[]>;
+
+type Retrieval = {
+  retrievalId: number;
+  partialProviderName: string;
+  type: string;
+  partitioning: string;
+  location: Location[];
+  measures: string[];
+  filterId: number;
+  measureProvider: string;
+  resultSizes: number[];
+  timingInfo: TimingInfo;
+  underlyingDataNodes: string[];
+};
+
+type DatabaseRetrieval = {
+  store: string;
+  fields: string[];
+  joinedMeasure: string[];
+  condition: string;
+  retrievalId: number;
+  resultSizes: number[];
+  timingInfo: TimingInfo;
+};
+
+type Dependencies = Record<string, number[]>;
+
+type Filter = {
+  id: number;
+  description: string;
+};
+
+type QuerySummary = {
+  measures: string[];
+  totalRetrievals: number;
+  retrievalCountByType: Record<string, number>;
+  partitioningCountByType: Record<string, number>;
+  resultSizeByPartitioning: Record<string, number>;
+  partialProviders: string[];
+  totalDatabaseResultSize: number;
+};
+
+export type QueryPlan = {
+  planInfo: EmptyObject;
+  aggregateRetrievals: Retrieval[];
+  dependencies: Dependencies;
+  databaseRetrievals: DatabaseRetrieval[];
+  databaseDependencies: Dependencies;
+  queryFilters: Filter[];
+  querySummary: QuerySummary;
+};


### PR DESCRIPTION
# Issue Number:

Fix issue #24 

# Description:

Create and use the type of the QueryPlan response, according to [this site](https://activepivot-ranch.activeviam.com:6100/activeviam/swagger-ui/index.html#/queries-rest-service-controller/mdxQueryPlan#model-JsonQueryPlanData)'s `JsonQueryPlanData` schema.

# How to test:

Send an MDX query and test that the response still displays correctly.

# Other notes:

Woohoo, the template works!