### PR TITLE
fix: data is an array of QueryPlan

### DIFF
--- a/lib/functions/postRequest.ts
+++ b/lib/functions/postRequest.ts
@@ -6,8 +6,8 @@ export async function postRequest(
   payload: { mdx: string },
   username: string,
   password: string,
-): Promise<QueryPlan> {
-  const response = await axios.post<QueryPlan>(url, payload, {
+): Promise<QueryPlan[]> {
+  const response = await axios.post<QueryPlan[]>(url, payload, {
     auth: {
       username,
       password,

--- a/lib/redux/queryPlanReducer.ts
+++ b/lib/redux/queryPlanReducer.ts
@@ -1,7 +1,7 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { QueryPlan } from "../types";
 
-type State = QueryPlan | "";
+type State = QueryPlan[] | "";
 
 const initialState = "" as State;
 


### PR DESCRIPTION
# Issue Number:

Not related to an open issue

# Description:

data must be an array of QueryPlan and not a single QueryPlan

# How to test:

Check that the type of the shared data is correct: an array of QueryPlan and that the properties can be called

# Other notes:
