### PR TITLE
Fix issue #41: 10 slowest nodes

### DIFF
--- a/app/nodes/layout.tsx
+++ b/app/nodes/layout.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from "next";
+import type { ReactElement } from "react";
+
+export const metadata: Metadata = {
+  title: "Query Plan nodes",
+};
+
+export default function NodesLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>): ReactElement {
+  return <>{children}</>;
+}

--- a/app/nodes/page.tsx
+++ b/app/nodes/page.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { getQueryPlan } from "@/lib/redux";
+import {
+  AggregateRetrieval,
+  DatabaseRetrieval,
+  TimingInfo,
+} from "@/lib/types/queryPlan";
+import {
+  Box,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+  Paper,
+} from "@mui/material";
+import { ReactElement, useMemo } from "react";
+import { useSelector } from "react-redux";
+
+interface ProcessedNode {
+  id: string;
+  type: "Aggregate" | "Database";
+  totalTiming: number;
+}
+
+const calculateTotalTiming = (timingInfo: TimingInfo): number => {
+  return Object.values(timingInfo)
+    .flat()
+    .reduce((sum, value) => sum + value, 0);
+};
+
+export default function NodesPage(): ReactElement {
+  const queryPlan = useSelector(getQueryPlan);
+
+  const slowestNodes: ProcessedNode[] = useMemo(() => {
+    if (!queryPlan || queryPlan.length === 0) return [];
+
+    const allNodes: ProcessedNode[] = queryPlan.flatMap((queryPlan) => {
+      const aggregateNodes: ProcessedNode[] = queryPlan.aggregateRetrievals.map(
+        (node: AggregateRetrieval) => ({
+          id: `Aggregate-${node.retrievalId}`,
+          type: "Aggregate",
+          totalTiming: calculateTotalTiming(node.timingInfo),
+        }),
+      );
+
+      const databaseNodes: ProcessedNode[] = queryPlan.databaseRetrievals.map(
+        (node: DatabaseRetrieval) => ({
+          id: `Database-${node.retrievalId}`,
+          type: "Database",
+          totalTiming: calculateTotalTiming(node.timingInfo),
+        }),
+      );
+
+      return [...aggregateNodes, ...databaseNodes];
+    });
+
+    // Sort nodes by totalTiming in descending order and take the top 10
+    return allNodes.sort((a, b) => b.totalTiming - a.totalTiming).slice(0, 10);
+  }, [queryPlan]);
+
+  if (!queryPlan || queryPlan.length === 0) {
+    return (
+      <Typography>Please send a query to see the slowest nodes</Typography>
+    );
+  }
+
+  return (
+    <Box padding={2} width="100%">
+      <Typography variant="h4" gutterBottom>
+        Top 10 Slowest Nodes
+      </Typography>
+      <TableContainer component={Paper}>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell>Node ID</TableCell>
+              <TableCell>Type</TableCell>
+              <TableCell align="right">Total Timing (ms)</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {slowestNodes.map((node) => (
+              <TableRow key={node.id}>
+                <TableCell>{node.id}</TableCell>
+                <TableCell>{node.type}</TableCell>
+                <TableCell align="right">
+                  {node.totalTiming.toFixed(2)}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </Box>
+  );
+}

--- a/app/nodes/page.tsx
+++ b/app/nodes/page.tsx
@@ -16,6 +16,8 @@ import {
   Select,
   FormControl,
   InputLabel,
+  Grid2,
+  Slider,
 } from "@mui/material";
 import { ReactElement, useState } from "react";
 import { useSelector } from "react-redux";
@@ -24,6 +26,7 @@ export default function NodesPage(): ReactElement {
   const queryPlan = useSelector(getQueryPlan);
 
   const [selectedIndex, setSelectedIndex] = useState<number>(0);
+  const [numberOfNodes, setNumberOfNodes] = useState<number>(10);
 
   if (!queryPlan || queryPlan.length === 0) {
     return (
@@ -36,13 +39,13 @@ export default function NodesPage(): ReactElement {
   const slowestNodes = getSlowestNodes(
     aggregateRetrievals,
     databaseRetrievals,
-    10,
+    numberOfNodes,
   );
 
   return (
     <Box padding={2} width="100%">
       <Typography variant="h4" gutterBottom>
-        Top 10 Slowest Nodes
+        {`Top ${numberOfNodes} Slowest Nodes`}
       </Typography>
 
       <FormControl sx={{ padding: 2 }}>
@@ -63,6 +66,19 @@ export default function NodesPage(): ReactElement {
           ))}
         </Select>
       </FormControl>
+
+      <Grid2>
+        <InputLabel id="query-plan-select-number-of-nodes">
+          Select the number of nodes
+        </InputLabel>
+        <Slider
+          sx={{ width: { xs: "100%", md: "30%" } }}
+          value={numberOfNodes}
+          onChange={(_event, value) => setNumberOfNodes(value as number)}
+          min={1}
+          max={aggregateRetrievals.length + databaseRetrievals.length}
+        />
+      </Grid2>
 
       <TableContainer component={Paper}>
         <Table>

--- a/app/nodes/page.tsx
+++ b/app/nodes/page.tsx
@@ -45,7 +45,7 @@ export default function NodesPage(): ReactElement {
   return (
     <Box padding={2} width="100%">
       <Typography variant="h4" gutterBottom>
-        {`Top ${numberOfNodes} Slowest Nodes`}
+        Top {numberOfNodes} Slowest Nodes
       </Typography>
 
       <FormControl sx={{ padding: 2 }}>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -19,6 +19,9 @@ export function Header(): ReactElement {
           <Link href="/timeline">
             <Button variant="outlined">Timeline</Button>
           </Link>
+          <Link href="/nodes">
+            <Button variant="outlined">Nodes</Button>
+          </Link>
         </Toolbar>
       </Container>
     </AppBar>

--- a/lib/functions/slowestNodes.ts
+++ b/lib/functions/slowestNodes.ts
@@ -7,16 +7,16 @@ interface ProcessedNode {
 }
 
 function computeTiming(timingInfo: TimingInfo): number {
-  const startTimes: number[] = timingInfo["startTime"];
-  const elapsedTimes: number[] = timingInfo["elapsedTime"];
+  const startTimes: number[] = timingInfo.startTime;
+  const elapsedTimes: number[] = timingInfo.elapsedTime;
 
   if (startTimes.length != elapsedTimes.length) {
     return 0;
   }
 
-  const endTimes: number[] = startTimes.map(function (num, idx) {
-    return num + elapsedTimes[idx];
-  });
+  const endTimes: number[] = startTimes.map(
+    (num, idx) => num + elapsedTimes[idx],
+  );
 
   return (
     endTimes.reduce((a, b) => Math.max(a, b)) -
@@ -29,20 +29,16 @@ export function getSlowestNodes(
   databaseRetrievals: DatabaseRetrieval[],
   numberOfNodes: number,
 ): ProcessedNode[] {
-  const aggregateNodes: ProcessedNode[] = aggregateRetrievals.map(
-    (node: AggregateRetrieval) => ({
-      id: `Aggregate ${node.retrievalId}`,
-      type: "Aggregate",
-      timing: computeTiming(node.timingInfo),
-    }),
-  );
-  const databaseNodes: ProcessedNode[] = databaseRetrievals.map(
-    (node: DatabaseRetrieval) => ({
-      id: `Database ${node.retrievalId}`,
-      type: "Database",
-      timing: computeTiming(node.timingInfo),
-    }),
-  );
+  const aggregateNodes: ProcessedNode[] = aggregateRetrievals.map((node) => ({
+    id: `Aggregate ${node.retrievalId}`,
+    type: "Aggregate",
+    timing: computeTiming(node.timingInfo),
+  }));
+  const databaseNodes: ProcessedNode[] = databaseRetrievals.map((node) => ({
+    id: `Database ${node.retrievalId}`,
+    type: "Database",
+    timing: computeTiming(node.timingInfo),
+  }));
 
   const allNodes: ProcessedNode[] = [...aggregateNodes, ...databaseNodes];
 

--- a/lib/functions/slowestNodes.ts
+++ b/lib/functions/slowestNodes.ts
@@ -1,0 +1,50 @@
+import { AggregateRetrieval, DatabaseRetrieval, TimingInfo } from "../types";
+
+interface ProcessedNode {
+  id: string;
+  type: "Aggregate" | "Database";
+  timing: number;
+}
+
+function computeTiming(timingInfo: TimingInfo): number {
+  const startTimes: number[] = timingInfo["startTime"];
+  const elapsedTimes: number[] = timingInfo["elapsedTime"];
+
+  if (startTimes.length != elapsedTimes.length) {
+    return 0;
+  }
+
+  const endTimes: number[] = startTimes.map(function (num, idx) {
+    return num + elapsedTimes[idx];
+  });
+
+  return (
+    endTimes.reduce((a, b) => Math.max(a, b)) -
+    startTimes.reduce((a, b) => Math.min(a, b))
+  );
+}
+
+export function getSlowestNodes(
+  aggregateRetrievals: AggregateRetrieval[],
+  databaseRetrievals: DatabaseRetrieval[],
+  numberOfNodes: number,
+): ProcessedNode[] {
+  const aggregateNodes: ProcessedNode[] = aggregateRetrievals.map(
+    (node: AggregateRetrieval) => ({
+      id: `Aggregate ${node.retrievalId}`,
+      type: "Aggregate",
+      timing: computeTiming(node.timingInfo),
+    }),
+  );
+  const databaseNodes: ProcessedNode[] = databaseRetrievals.map(
+    (node: DatabaseRetrieval) => ({
+      id: `Database ${node.retrievalId}`,
+      type: "Database",
+      timing: computeTiming(node.timingInfo),
+    }),
+  );
+
+  const allNodes: ProcessedNode[] = [...aggregateNodes, ...databaseNodes];
+
+  return allNodes.sort((a, b) => b.timing - a.timing).slice(0, numberOfNodes);
+}

--- a/lib/types/queryPlan.ts
+++ b/lib/types/queryPlan.ts
@@ -31,7 +31,7 @@ type Location = {
   path: string[];
 };
 
-type TimingInfo = Record<string, number[]>;
+export type TimingInfo = Record<string, number[]>;
 
 export type AggregateRetrieval = {
   retrievalId: number;


### PR DESCRIPTION
# Issue Number:

Fix issue #41  

# Description:

Add a page to visualize the slowest nodes
you can choose a query plan pass and the number of nodes you wan to see

# How to test:

Launch the app.
Go to the "Nodes" page.
Try to change the pass and the number of nodes
(No added dependency)