### PR TITLE
Solving issue #53: displaying aggregated data of all SelectPass

### DIFF
--- a/app/summary/page.tsx
+++ b/app/summary/page.tsx
@@ -33,6 +33,7 @@ export default function SummaryPage(): ReactElement {
   const queryPlan = useSelector(getQueryPlan);
   const selectedIndex = useSelector(getSelectedIndex);
   const [searchTerm, setSearchTerm] = useState("");
+  const [isDataAggregated, setIsDataAggregated] = useState<boolean>(false);
   const [isGroupedTimings, setIsGroupedTimings] = useState<boolean>(false);
   const [isGroupedNumbers, setIsGroupedNumbers] = useState<boolean>(false);
 
@@ -269,6 +270,14 @@ export default function SummaryPage(): ReactElement {
 
   return (
     <Grid2 container spacing={1}>
+      <Card>
+        <CardContent>
+          <Switch
+            checked={isDataAggregated}
+            onChange={() => setIsDataAggregated((prev) => !prev)}
+          />
+        </CardContent>
+      </Card>
       <Card>
         <CardContent>
           <Typography variant="h6">Elapsed timings of retrievals</Typography>


### PR DESCRIPTION
# Issue Number:

Closes #53 
_The issue will be automatically closed if merged_

# Description:

An option will be added to display the data of all aggregated selectPass
⚠️ It should not be available in the others pages, so we need to see how it will be done with #55 

# How to test:

Launch the app `yarn dev`

Go to page: summary
Check that you can see all the aggregated data and that there is no bugs
