### PR TITLE
Fix issue #60: Lint at root dir

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -4,8 +4,8 @@ const nextConfig: NextConfig = {
   async redirects() {
     return [
       {
-        source: '/',
-        destination: '/submit-query',
+        source: "/",
+        destination: "/submit-query",
         permanent: true,
       },
     ];

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "format": "prettier --write .",
+    "format": "prettier --write --no-error-on-unmatched-pattern ./src ./app ./pages ./components ./lib",
     "install:ci": "yarn install --frozen-lockfile"
   },
   "dependencies": {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,7 +1,7 @@
 import type { Config } from "tailwindcss";
 
 const config: Config = {
-  darkMode: 'media',
+  darkMode: "media",
   content: [
     "./pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./components/**/*.{js,ts,jsx,tsx,mdx}",


### PR DESCRIPTION
# Issue Number:

Closes #60 

# Description:

Now `yarn format` is run on the same dirs as `next lint`; see first lines of `next lint -h` below:

```
Usage: next lint [directory] [options]

Runs ESLint for all files in the `/src`, `/app`, `/pages`, `/components`, and `/lib` directories.
```

# How to test:

- Try chaging files outside these dirs with something that the formatter shouldn't allow (single quotes or spaces)
- Verify that both `yarn lint` (`next lint`) and `yarn format` don't change them back
