### PR TITLE
Fix issue #80: Put tests at the end to check lint

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,8 +30,8 @@ jobs:
       - name: Build
         run: yarn build
 
-      - name: Test
-        run: yarn test --maxWorkers=4
-
       - name: Lint
         run: yarn lint
+
+      - name: Test
+        run: yarn test --maxWorkers=4


### PR DESCRIPTION
# Issue Number:

Closes #80 

# Description:

Put the tests at the end at the pipeline so that the lint is still checked

# How to test:

Look at the pipeline that ran on this PR