### PR TITLE
Fix issue #75: don't show PlanSelector when in query page

### DIFF
--- a/components/PlanSelector.tsx
+++ b/components/PlanSelector.tsx
@@ -7,6 +7,7 @@ import {
   useAppDispatch,
 } from "@/lib/redux";
 import { FormControl, InputLabel, MenuItem, Select } from "@mui/material";
+import { usePathname } from "next/navigation";
 import { type ReactElement } from "react";
 import { useSelector } from "react-redux";
 
@@ -15,7 +16,10 @@ export default function PlanSelector(): ReactElement {
   const selectedIndex = useSelector(getSelectedIndex);
   const dispatch = useAppDispatch();
 
-  if (!queryPlan || queryPlan.length < 2) return <></>;
+  const pathname = usePathname();
+
+  if (pathname == "/submit-query" || !queryPlan || queryPlan.length < 2)
+    return <></>;
 
   return (
     <FormControl fullWidth>


### PR DESCRIPTION
# Issue Number:

Closes #75 
_The issue will be automatically closed if merged_

# Description:

Hide the PlanSelector when in the submit-query page.

# How to test:

- Launch the app `yarn dev`
- Go to page `submit-query`
- Submit a query
- The PlanSelector should not appear
- Go to any visualisation page
- The PlanSelector should appear