### PR TITLE
Fix issue #86: time scale for timeline

### DIFF
--- a/app/timeline/page.tsx
+++ b/app/timeline/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { CoreTimeline, RetrievalDialog } from "@/components";
+import { CoreTimeline, RetrievalDialog, TimeScale } from "@/components";
 import { buildTimeline } from "@/lib/functions";
 import { getQueryPlan, getSelectedIndex } from "@/lib/redux";
 import {
@@ -175,6 +175,25 @@ export default function TimelinePage(): ReactElement {
             </Grid2>
           </Grid2>
         ))}
+        <Grid2
+          container
+          spacing={2}
+          alignItems="center"
+          width={`${contentWidth}px`}
+        >
+          {contentWidth > 200 && (
+            <Grid2 size={1}>
+              {contentWidth > 520 && (
+                <Typography variant="subtitle2" fontStyle="italic">
+                  Time (ms)
+                </Typography>
+              )}
+            </Grid2>
+          )}
+          <Grid2 size={11}>
+            <TimeScale maxEnd={maxEnd} scale={scale} />
+          </Grid2>
+        </Grid2>
       </Box>
       <RetrievalDialog
         retrieval={selectedRetrieval}

--- a/components/TimeScale.tsx
+++ b/components/TimeScale.tsx
@@ -1,0 +1,42 @@
+import { Box, Typography } from "@mui/material";
+import { type ReactElement } from "react";
+
+type TimeScaleProps = {
+  maxEnd: number;
+  scale: number;
+};
+
+const PIXELS_PER_TICK = 100;
+
+export function TimeScale({ maxEnd, scale }: TimeScaleProps): ReactElement {
+  // Dynamically calculate interval based on the desired number of ticks
+  const interval = Math.ceil(PIXELS_PER_TICK / scale);
+  const ticks = Array.from(
+    { length: Math.ceil(maxEnd / interval) },
+    (_, i) => i * interval,
+  );
+
+  return (
+    <Box
+      display="flex"
+      position="relative"
+      height="30px"
+      borderTop={1}
+      borderColor="primary.main"
+      marginTop={2}
+    >
+      {ticks.map((time) => (
+        <Box
+          key={time}
+          position="absolute"
+          left={`${time * scale}px`}
+          textAlign="center"
+          style={{ transform: "translateX(-50%)" }}
+        >
+          <Box width="1px" height="10px" bgcolor="primary.main" margin="auto" />
+          <Typography variant="caption">{time}</Typography>
+        </Box>
+      ))}
+    </Box>
+  );
+}

--- a/components/index.ts
+++ b/components/index.ts
@@ -4,3 +4,4 @@ export * from "./Header";
 export * from "./PlanSelector";
 export * from "./Providers";
 export * from "./RetrievalDialog";
+export * from "./TimeScale";


### PR DESCRIPTION
# Issue Number:

Closes #86 
_The issue will be automatically closed if merged_

# Description:

Add a time scale under the timescale.
The ticks are evenly spaced, they are added/removed when zooming/dezooming

# How to test:

- Launch the app `yarn dev`
- Send a query
- Go to the timeline page and see the time scale
