### PR TITLE
Fixing issue #90 : being more clear about file inputs

### DIFF
--- a/app/submit-query/page.tsx
+++ b/app/submit-query/page.tsx
@@ -145,6 +145,7 @@ export default function SubmitQueryPage(): ReactElement {
                     />
                     <FileUploader
                       onFileLoad={(content) => setFieldValue("text", content)}
+                      label="Or upload an MDX request file (.txt)"
                     />
 
                     <Button
@@ -174,6 +175,8 @@ export default function SubmitQueryPage(): ReactElement {
 
               <FileUploader
                 onFileLoad={(content) => setManualQueryPlan(content)}
+                accept=".txt,.json"
+                label="Or upload a query plan file (.txt or .json)"
               />
 
               <Button

--- a/components/FileUploader.tsx
+++ b/components/FileUploader.tsx
@@ -1,7 +1,7 @@
 export function FileUploader({
   onFileLoad,
-  accept = ".txt, .json",
-  label = "Or upload a file:",
+  accept = ".txt",
+  label = "Upload a file:",
 }: {
   onFileLoad: (content: string) => void;
   accept?: string;


### PR DESCRIPTION
# Issue Number:

Closes #90 
_The issue will be automatically closed if merged_

# Description:

The default parameters values for the FileUploader component have been set to ".txt" and "Upload a file"
I precised further information on both components when they are called.
MDX request file must be .txt
Query plan can be .txt or .json


# How to test:

Launch the app `yarn dev`

Go to page: submit-query
Check that the information appears on the file uploaders, and that the extension requirements listed above are required.

# Other notes:
