### PR TITLE
Fixing issue #89 : exporting Query plans as JSON files

### DIFF
--- a/app/submit-query/page.tsx
+++ b/app/submit-query/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { FileUploader } from "@/components";
+import { FileExporter, FileUploader } from "@/components";
 import { postRequest } from "@/lib/functions";
 import { getQueryPlan, setQueryPlan, useAppDispatch } from "@/lib/redux";
 import { CopyAll } from "@mui/icons-material";
@@ -216,6 +216,8 @@ export default function SubmitQueryPage(): ReactElement {
                   >
                     Copy Query Plan
                   </Button>
+
+                  <FileExporter data={queryPlan} filename="queryPlan.json" />
                 </Grid2>
               </Grid2>
               <Typography

--- a/app/submit-query/page.tsx
+++ b/app/submit-query/page.tsx
@@ -9,8 +9,9 @@ import {
   CardContent,
   CardHeader,
   Grid2,
-  Typography,
   TextField,
+  Tooltip,
+  Typography,
   Switch,
 } from "@mui/material";
 import { isAxiosError } from "axios";
@@ -203,20 +204,22 @@ export default function SubmitQueryPage(): ReactElement {
                 <Grid2 className="font-medium text-lg">
                   Saved query plan :
                 </Grid2>
-                <Grid2>
-                  <Button
-                    onClick={() =>
-                      navigator.clipboard.writeText(
-                        JSON.stringify(queryPlan, null, 2),
-                      )
-                    }
-                    variant="text"
-                    endIcon={<CopyAll />}
-                    className="text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300"
-                  >
-                    Copy Query Plan
-                  </Button>
-
+                <Grid2 container direction="column" spacing={1}>
+                  <Tooltip title="Copy query plan">
+                    <Button
+                      onClick={() =>
+                        navigator.clipboard.writeText(
+                          JSON.stringify(queryPlan, null, 2),
+                        )
+                      }
+                      variant="outlined"
+                      className="text-blue-600
+                      dark:text-blue-400 hover:text-blue-800
+                      dark:hover:text-blue-300"
+                    >
+                      <CopyAll />
+                    </Button>
+                  </Tooltip>
                   <FileExporter data={queryPlan} filename="queryPlan.json" />
                 </Grid2>
               </Grid2>

--- a/app/submit-query/page.tsx
+++ b/app/submit-query/page.tsx
@@ -207,7 +207,7 @@ export default function SubmitQueryPage(): ReactElement {
                 <Grid2 className="font-medium text-lg">
                   Saved query plan :
                 </Grid2>
-                <Grid2 container direction="column" spacing={1}>
+                <Grid2 container direction="row" spacing={1}>
                   <Tooltip title="Copy query plan">
                     <Button
                       onClick={() =>

--- a/components/FileExporter.tsx
+++ b/components/FileExporter.tsx
@@ -1,0 +1,32 @@
+import { Button } from "@mui/material";
+
+export function FileExporter({
+  data,
+  filename = "data.json",
+}: {
+  data: any;
+  filename?: string;
+}) {
+  const handleExport = (): void => {
+    const blob = new Blob([JSON.stringify(data, null, 2)], {
+      type: "application/json",
+    });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  };
+
+  return (
+    <Button
+      onClick={handleExport}
+      variant="contained"
+      className="text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300"
+    >
+      Export as JSON
+    </Button>
+  );
+}

--- a/components/FileExporter.tsx
+++ b/components/FileExporter.tsx
@@ -1,4 +1,5 @@
-import { Button } from "@mui/material";
+import { Button, Tooltip } from "@mui/material";
+import { FileDownload } from "@mui/icons-material";
 import { QueryPlan } from "../lib/types";
 
 export function FileExporter({
@@ -22,12 +23,10 @@ export function FileExporter({
   };
 
   return (
-    <Button
-      onClick={handleExport}
-      variant="contained"
-      className="text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300"
-    >
-      Export as JSON
-    </Button>
+    <Tooltip title="Export as JSON">
+      <Button onClick={handleExport} variant="outlined">
+        <FileDownload />
+      </Button>
+    </Tooltip>
   );
 }

--- a/components/FileExporter.tsx
+++ b/components/FileExporter.tsx
@@ -1,10 +1,11 @@
 import { Button } from "@mui/material";
+import { QueryPlan } from "../lib/types";
 
 export function FileExporter({
   data,
   filename = "data.json",
 }: {
-  data: any;
+  data: QueryPlan[];
   filename?: string;
 }) {
   const handleExport = (): void => {

--- a/components/index.ts
+++ b/components/index.ts
@@ -1,4 +1,5 @@
 export * from "./CoreTimeline";
+export * from "./FileExporter";
 export * from "./FileUploader";
 export * from "./Header";
 export * from "./PlanSelector";


### PR DESCRIPTION
# Issue Number: 89

Closes #89 
_The issue will be automatically closed if merged_

# Description:

If there is a loaded query plan, it can be exported as a JSON file

# How to test:

Launch the app `yarn dev`

Go to page: submit-query
Load a query plan
Check that you can download it as JSON file and that the file is correct