### PR TITLE
Fix issue #93: query plan overflow

### DIFF
--- a/app/submit-query/page.tsx
+++ b/app/submit-query/page.tsx
@@ -226,6 +226,8 @@ export default function SubmitQueryPage(): ReactElement {
                 borderRadius={1}
                 padding={2}
                 className="text-sm bg-white text-gray-800 dark:bg-gray-900 dark:text-gray-100"
+                width="100%"
+                sx={{ overflowX: "auto" }}
               >
                 {JSON.stringify(queryPlan, null, 2)}
               </Typography>


### PR DESCRIPTION
# Issue Number:

Closes #93 
_The issue will be automatically closed if merged_

# Description:

Add overflow options for the query plan display box

# How to test:

- Launch the app `yarn dev`
- Send a request
- Reduce the width of your screen. Now if it overflows, the black stays inside the green, and you can slide the text left/right
