### PR TITLE
Fix issue #104: different colors for different types in timeline

### DIFF
--- a/components/CoreTimeline.tsx
+++ b/components/CoreTimeline.tsx
@@ -1,3 +1,4 @@
+import { TIMELINE_COLORS } from "@/lib/functions";
 import { TimelineTiming, TimingType } from "@/lib/types";
 import { Box, Tooltip } from "@mui/material";
 import { ReactElement } from "react";
@@ -21,8 +22,7 @@ export function CoreTimeline({
       width="100%"
       height={30}
       border={1}
-      borderColor="black"
-      bgcolor="primary.main"
+      borderColor="primary.main"
       borderRadius={2}
       overflow="hidden"
     >
@@ -46,7 +46,7 @@ export function CoreTimeline({
             border={1}
             borderColor="black"
             borderRadius={2}
-            bgcolor="primary.dark"
+            bgcolor={TIMELINE_COLORS[type]}
             onClick={() => openRetrievalDialog(retrievalId, type)}
           />
         </Tooltip>

--- a/components/Providers.tsx
+++ b/components/Providers.tsx
@@ -9,7 +9,8 @@ import { Provider } from "react-redux";
 
 const theme = createTheme({
   colorSchemes: {
-    dark: true,
+    dark: { palette: { secondary: { main: "#FFB84D", dark: "#FFA85D" } } },
+    light: { palette: { secondary: { main: "#FFB84D", dark: "#FFA04D" } } },
   },
 });
 

--- a/lib/functions/buildTimeline.ts
+++ b/lib/functions/buildTimeline.ts
@@ -5,6 +5,13 @@ import {
   TimelineTiming,
 } from "@/lib/types";
 
+export const TIMELINE_COLORS: Record<string, string> = {
+  AggregateRetrieval: "secondary.dark",
+  AggregateRetrievalExecutionContext: "secondary.light",
+  DatabaseRetrieval: "primary.dark",
+  DatabaseRetrievalExecutionContext: "primary.light",
+};
+
 export function buildTimeline(
   aggregateRetrievals: AggregateRetrieval[],
   databaseRetrievals: DatabaseRetrieval[],


### PR DESCRIPTION
# Issue Number:

Closes #104 
_The issue will be automatically closed if merged_

# Description:

 Have different colors for different types in timeline, for easier analysis

# How to test:

- Launch the app `yarn dev`
- Send a query
- Go to timeline page, and see

# Other notes:

Should I put a legend on top?