### PR TITLE
Fix issue #108: use onScroll and onWheel if possible

### DIFF
--- a/app/timeline/page.tsx
+++ b/app/timeline/page.tsx
@@ -93,29 +93,17 @@ export default function TimelinePage(): ReactElement {
   }, [containerWidth, maxEnd]);
 
   // Synchronize horizontal scroll between timeline and scale
-  useEffect(() => {
-    const container = containerRef.current;
+  function handleScroll(source: "container" | "scale"): void {
+    const containerDiv = containerRef.current;
     const scaleDiv = scaleRef.current;
 
-    function handleScroll(source: "container" | "scale"): void {
-      if (!container || !scaleDiv) return;
+    if (!containerDiv || !scaleDiv) return;
 
-      if (container.scrollLeft !== scaleDiv.scrollLeft) {
-        if (source === "container") scaleDiv.scrollLeft = container.scrollLeft;
-        else container.scrollLeft = scaleDiv.scrollLeft;
-      }
+    if (containerDiv.scrollLeft !== scaleDiv.scrollLeft) {
+      if (source === "container") scaleDiv.scrollLeft = containerDiv.scrollLeft;
+      else containerDiv.scrollLeft = scaleDiv.scrollLeft;
     }
-
-    if (!container || !scaleDiv) return;
-
-    container.addEventListener("scroll", () => handleScroll("container"));
-    scaleDiv.addEventListener("scroll", () => handleScroll("scale"));
-
-    return () => {
-      container.removeEventListener("scroll", () => handleScroll("container"));
-      scaleDiv.removeEventListener("scroll", () => handleScroll("scale"));
-    };
-  }, []);
+  }
 
   if (!queryPlan) return <>Please send a query to see the graph</>;
 
@@ -199,6 +187,7 @@ export default function TimelinePage(): ReactElement {
             overscrollBehaviorX: "none",
             scrollbarWidth: "none",
           }}
+          onScroll={() => handleScroll("container")}
           ref={containerRef}
         >
           {Array.from({ length: nbCores }).map((_, index) => (
@@ -218,6 +207,7 @@ export default function TimelinePage(): ReactElement {
         contentWidth={contentWidth}
         scale={scale}
         maxEnd={maxEnd}
+        onScroll={() => handleScroll("scale")}
         ref={scaleRef}
       />
       {/* Dialog for retrieval details */}

--- a/components/timeline/TimelineFooter.tsx
+++ b/components/timeline/TimelineFooter.tsx
@@ -7,6 +7,7 @@ type TimelineFooterProps = {
   maxEnd: number;
   scale: number;
   ref: RefObject<HTMLDivElement>;
+  onScroll: () => void;
 };
 
 export function TimelineFooter({
@@ -14,6 +15,7 @@ export function TimelineFooter({
   maxEnd,
   scale,
   ref,
+  onScroll,
 }: TimelineFooterProps): ReactElement {
   return (
     <Grid2
@@ -35,6 +37,7 @@ export function TimelineFooter({
           overflowY: "hidden",
           overscrollBehaviorX: "none",
         }}
+        onScroll={onScroll}
         ref={ref}
       >
         <Grid2 width={`${contentWidth}px`}>


### PR DESCRIPTION
# Issue Number:

Closes #108 
_The issue will be automatically closed if merged_

# Description:

- [x] use `onScroll` instead of `useEffect`
- [x ] ~use `onWheel` instead of `useEffect`~ we decided it's better to keep it

# How to test:

- Launch the app `yarn dev`
- Send a query
- Go to the timeline page and see if scroll and wheel behavior still work

# Other notes:
