### PR TITLE
feat: isManual is now in redux and saved if page changes

### DIFF
--- a/app/submit-query/page.tsx
+++ b/app/submit-query/page.tsx
@@ -1,7 +1,13 @@
 "use client";
 import { FileExporter, FileUploader } from "@/components";
 import { postRequest } from "@/lib/functions";
-import { getQueryPlan, setQueryPlan, useAppDispatch } from "@/lib/redux";
+import {
+  getIsManual,
+  getQueryPlan,
+  setIsManual,
+  setQueryPlan,
+  useAppDispatch,
+} from "@/lib/redux";
 import { CopyAll } from "@mui/icons-material";
 import {
   Button,
@@ -24,9 +30,9 @@ const DEFAULT_URL =
 
 export default function SubmitQueryPage(): ReactElement {
   const [error, setError] = useState<string | null>(null);
-  const [isManualMode, setIsManualMode] = useState<boolean>(false);
   const [manualQueryPlan, setManualQueryPlan] = useState<string>("");
 
+  const isManualMode = useSelector(getIsManual);
   const dispatch = useAppDispatch();
   const queryPlan = useSelector(getQueryPlan);
 
@@ -85,7 +91,7 @@ export default function SubmitQueryPage(): ReactElement {
             <Typography>Query plan mode</Typography>
             <Switch
               checked={isManualMode}
-              onChange={() => setIsManualMode((prev) => !prev)}
+              onChange={() => dispatch(setIsManual(!isManualMode))}
             />
           </Grid2>
         }

--- a/lib/redux/queryPlanReducer.ts
+++ b/lib/redux/queryPlanReducer.ts
@@ -1,9 +1,17 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { QueryPlan } from "../types";
 
-type State = { queryPlan: QueryPlan[] | ""; selectedIndex: number };
+type State = {
+  queryPlan: QueryPlan[] | "";
+  selectedIndex: number;
+  isManual: boolean;
+};
 
-const initialState: State = { queryPlan: "", selectedIndex: 0 };
+const initialState: State = {
+  queryPlan: "",
+  selectedIndex: 0,
+  isManual: false,
+};
 
 export const queryPlanReducer = createSlice({
   name: "queryPlan",
@@ -15,13 +23,19 @@ export const queryPlanReducer = createSlice({
     setSelectedIndex(state, action: PayloadAction<number>) {
       state.selectedIndex = action.payload;
     },
+    setIsManual(state, action: PayloadAction<boolean>) {
+      state.isManual = action.payload;
+    },
   },
   selectors: {
     getQueryPlan: (state) => state.queryPlan,
     getSelectedIndex: (state) => state.selectedIndex,
+    getIsManual: (state) => state.isManual,
   },
 });
 
-export const { setQueryPlan, setSelectedIndex } = queryPlanReducer.actions;
+export const { setQueryPlan, setSelectedIndex, setIsManual } =
+  queryPlanReducer.actions;
 
-export const { getQueryPlan, getSelectedIndex } = queryPlanReducer.selectors;
+export const { getQueryPlan, getSelectedIndex, getIsManual } =
+  queryPlanReducer.selectors;


### PR DESCRIPTION
# Issue #116 

Closes #116 

# Description:

If the manual mode (entering a query plan directly and not a query) was selected, it is saved through page changes
Useful if there is several QPs to test

# How to test:

Launch the app `yarn dev`

Go to page: submit-query
Check that behaviour in description works