### PR TITLE
Issue #113: reorganising summary page display

### DIFF
--- a/app/summary/page.tsx
+++ b/app/summary/page.tsx
@@ -88,470 +88,498 @@ export default function SummaryPage(): ReactElement {
   } = pieData;
 
   return (
-    <Grid2 container spacing={1}>
-      {queryPlan.length >= 2 && (
-        <Card
-          style={{
-            backgroundColor: isDataAggregated
-              ? "rgb(40, 40, 40)"
-              : "rgb(20, 20, 20)",
-          }}
-        >
-          <CardContent>
-            <Typography display="flex" alignItems="center">
-              Aggregate all parts
-              <Tooltip title="Toggle this switch to aggregate all the data in one single page. Measures appearing twice will be excluded">
-                <IconButton size="small" style={{ marginLeft: 8 }}>
-                  <InfoIcon fontSize="small" />
-                </IconButton>
-              </Tooltip>
-            </Typography>
-            <Switch
-              checked={isDataAggregated}
-              onChange={() => setIsDataAggregated((prev) => !prev)}
-            />
-            <Typography>There are {queryPlan.length} Select Pass</Typography>
-          </CardContent>
-        </Card>
-      )}
-
-      <Card>
-        <CardContent>
-          <Typography variant="h6">Elapsed timings of retrievals</Typography>
-          <Grid2>
-            <Typography>Group retrievals</Typography>
-            <Switch
-              checked={isGroupedTimings}
-              onChange={() => setIsGroupedTimings((prev) => !prev)}
-            />
-          </Grid2>
-          <Grid2 container spacing={2}>
-            {!isGroupedTimings ? (
-              <Box
-                sx={{
-                  border: "1px solid #ccc",
-                  padding: 2,
-                  marginTop: 2,
-                  display: "flex",
-                }}
-              >
-                <ResponsiveContainer width={300} height={300}>
-                  <PieChart>
-                    <Pie
-                      data={pieDataElapsedTimings}
-                      dataKey="value"
-                      nameKey="name"
-                      cx="50%"
-                      cy="50%"
-                      outerRadius={100}
-                      isAnimationActive={false}
-                    >
-                      {pieDataElapsedTimings.map((entry) => (
-                        <Cell key={entry.name} fill={entry.fill} />
-                      ))}
-                    </Pie>
-                  </PieChart>
-                </ResponsiveContainer>
-
-                <Box sx={{ marginLeft: 2, flex: 1 }}>
-                  <Typography
-                    variant="body1"
-                    fontWeight="bold"
-                    marginBottom={1}
-                  >
-                    Elapsed timings
-                  </Typography>
-                  <Typography variant="body2" marginLeft={2}>
-                    Aggregate retrievals
-                  </Typography>
-                  <List dense sx={{ marginLeft: 4 }}>
-                    {Object.entries(aggregateRetrievalsElapsedTimings)
-                      .sort((a, b) => b[1] - a[1])
-                      .map(([key, value]) => (
-                        <ListItem key={key} disablePadding>
-                          <Box
-                            sx={{
-                              width: 12,
-                              height: 12,
-                              backgroundColor: retrievalsColors[key],
-                              marginRight: 1,
-                            }}
-                          />
-                          <ListItemText primary={`${key} : ${value} ms`} />
-                        </ListItem>
-                      ))}
-                  </List>
-                  <Typography variant="body2" marginLeft={2}>
-                    Database retrievals
-                  </Typography>
-                  <List dense sx={{ marginLeft: 4 }}>
-                    {Object.entries(databaseRetrievalsElapsedTimings)
-                      .sort((a, b) => b[1] - a[1])
-                      .map(([key, value]) => (
-                        <ListItem key={key} disablePadding>
-                          <Box
-                            sx={{
-                              width: 12,
-                              height: 12,
-                              backgroundColor: retrievalsColors[key],
-                              marginRight: 1,
-                            }}
-                          />
-                          <ListItemText primary={`${key} : ${value} ms`} />
-                        </ListItem>
-                      ))}
-                  </List>
-
-                  <Typography
-                    variant="body1"
-                    fontWeight="bold"
-                    marginBottom={1}
-                  >
-                    Elapsed timings (execution context)
-                  </Typography>
-                  <Typography variant="body2" marginLeft={2}>
-                    Aggregate
-                  </Typography>
-                  <List dense sx={{ marginLeft: 4 }}>
-                    {Object.entries(
-                      aggregateRetrievalsExecutionContextElapsedTimings,
-                    )
-                      .sort((a, b) => b[1] - a[1])
-                      .map(([key, value]) => (
-                        <ListItem key={key} disablePadding>
-                          <Box
-                            sx={{
-                              width: 12,
-                              height: 12,
-                              marginRight: 1,
-                            }}
-                          />
-                          <ListItemText primary={`${key} : ${value} ms`} />
-                        </ListItem>
-                      ))}
-                  </List>
-                  <Typography variant="body2" marginLeft={2}>
-                    Database
-                  </Typography>
-                  <List dense sx={{ marginLeft: 4 }}>
-                    {Object.entries(
-                      databaseRetrievalsExecutionContextElapsedTimings,
-                    )
-                      .sort((a, b) => b[1] - a[1])
-                      .map(([key, value]) => (
-                        <ListItem key={key} disablePadding>
-                          <Box
-                            sx={{
-                              width: 12,
-                              height: 12,
-                              marginRight: 1,
-                            }}
-                          />
-                          <ListItemText primary={`${key} : ${value} ms`} />
-                        </ListItem>
-                      ))}
-                  </List>
-                </Box>
-              </Box>
-            ) : (
-              <Box
-                sx={{
-                  border: "1px solid #ccc",
-                  padding: 2,
-                  marginTop: 2,
-                  display: "flex",
-                }}
-              >
-                <ResponsiveContainer width={300} height={300}>
-                  <PieChart>
-                    <Pie
-                      data={groupedPieDataElaspedTimings}
-                      dataKey="value"
-                      nameKey="name"
-                      cx="50%"
-                      cy="50%"
-                      outerRadius={100}
-                      isAnimationActive={false}
-                    >
-                      {groupedPieDataElaspedTimings.map((entry) => (
-                        <Cell key={entry.name} fill={entry.fill} />
-                      ))}
-                    </Pie>
-                  </PieChart>
-                </ResponsiveContainer>
-
-                <Box sx={{ marginLeft: 2, flex: 1 }}>
-                  <Typography
-                    variant="body1"
-                    fontWeight="bold"
-                    marginBottom={1}
-                  >
-                    Elapsed timings
-                  </Typography>
-                  <List dense sx={{ marginLeft: 2 }}>
-                    {Object.entries(groupedRetrievalsElapsedTimings)
-                      .sort((a, b) => b[1] - a[1])
-                      .map(([key, value]) => (
-                        <ListItem key={key} disablePadding>
-                          <Box
-                            sx={{
-                              width: 12,
-                              height: 12,
-                              backgroundColor: GROUP_COLORS[key],
-                              marginRight: 1,
-                            }}
-                          />
-                          <ListItemText primary={`${key} : ${value} ms`} />
-                        </ListItem>
-                      ))}
-                  </List>
-
-                  <Typography
-                    variant="body1"
-                    fontWeight="bold"
-                    marginBottom={1}
-                  >
-                    Elapsed timings (execution context)
-                  </Typography>
-                  <List dense sx={{ marginLeft: 2 }}>
-                    {Object.entries(
-                      groupedRetrievalsExecutionContextElapsedTimings,
-                    )
-                      .sort((a, b) => b[1] - a[1])
-                      .map(([key, value]) => (
-                        <ListItem key={key} disablePadding>
-                          <Box
-                            sx={{
-                              width: 12,
-                              height: 12,
-                              marginRight: 1,
-                            }}
-                          />
-                          <ListItemText primary={`${key} : ${value} ms`} />
-                        </ListItem>
-                      ))}
-                  </List>
-                </Box>
-              </Box>
-            )}
-          </Grid2>
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardContent>
-          <Grid2 container spacing={2}>
-            <Grid2>
-              <Typography variant="h6">Global timings</Typography>
-              {selectedQueryPlan.planInfo?.globalTimings ? (
-                <List dense sx={{ marginLeft: 4 }}>
-                  {Object.entries(selectedQueryPlan.planInfo.globalTimings).map(
-                    ([key, value]) => (
-                      <ListItem key={key} disablePadding>
-                        <ListItemText primary={`${key} : ${value} ms`} />
-                      </ListItem>
-                    ),
-                  )}
-                </List>
-              ) : (
-                <Typography variant="body2" sx={{ marginLeft: 4 }}>
-                  No global timings available.
-                </Typography>
-              )}
-            </Grid2>
-          </Grid2>
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardContent>
-          <Grid2 container direction="column" spacing={2}>
-            <Grid2>
-              <Typography variant="h6">Measures</Typography>
-            </Grid2>
-            <Grid2>
-              <TextField
-                fullWidth
-                label="Search Measures"
-                variant="outlined"
-                value={searchTerm}
-                onChange={(e) => setSearchTerm(e.target.value)}
+    <Grid2 container spacing={2}>
+      <Grid2 container spacing={1}>
+        {queryPlan.length >= 2 && (
+          <Card
+            style={{
+              backgroundColor: isDataAggregated
+                ? "rgb(40, 40, 40)"
+                : "rgb(20, 20, 20)",
+            }}
+          >
+            <CardContent>
+              <Typography display="flex" alignItems="center">
+                Aggregate all parts
+                <Tooltip title="Toggle this switch to aggregate all the data in one single page. Measures appearing twice will be excluded">
+                  <IconButton size="small" style={{ marginLeft: 8 }}>
+                    <InfoIcon fontSize="small" />
+                  </IconButton>
+                </Tooltip>
+              </Typography>
+              <Switch
+                checked={isDataAggregated}
+                onChange={() => setIsDataAggregated((prev) => !prev)}
               />
-            </Grid2>
-            <Box
-              sx={{
-                border: "1px solid #ccc",
-                padding: 2,
-                marginTop: 2,
-              }}
-            >
-              <Grid2>
-                <List dense sx={{ marginLeft: 4 }}>
-                  {filteredMeasures.map(([key, value]) => (
-                    <ListItem key={key} disablePadding>
-                      <ListItemText primary={`- ${value}`} />
-                    </ListItem>
-                  ))}
-                </List>
-              </Grid2>
-            </Box>
-          </Grid2>
-        </CardContent>
-      </Card>
+              <Typography>There are {queryPlan.length} Select Pass</Typography>
+            </CardContent>
+          </Card>
+        )}
+      </Grid2>
 
-      <Card>
-        <CardContent>
-          <Typography variant="h6">Summary information</Typography>
-          <Grid2>
-            <Typography>Group retrievals</Typography>
-            <Switch
-              checked={isGroupedNumbers}
-              onChange={() => setIsGroupedNumbers((prev) => !prev)}
-            />
-          </Grid2>
-
-          {!isGroupedNumbers ? (
-            <Grid2 container spacing={2}>
-              <Box
-                sx={{
-                  border: "1px solid #ccc",
-                  padding: 2,
-                  marginTop: 2,
-                  display: "flex",
-                }}
-              >
-                <ResponsiveContainer width={300} height={300}>
-                  <PieChart>
-                    <Pie
-                      data={pieDataRetrievalsTypeCounts}
-                      dataKey="value"
-                      nameKey="name"
-                      cx="50%"
-                      cy="50%"
-                      outerRadius={100}
-                      isAnimationActive={false}
-                    >
-                      {pieDataRetrievalsTypeCounts.map((entry) => (
-                        <Cell key={entry.name} fill={entry.fill} />
-                      ))}
-                    </Pie>
-                  </PieChart>
-                </ResponsiveContainer>
-                <Box sx={{ marginLeft: 2, flex: 1 }}>
-                  <Typography variant="body1" fontWeight="bold">
-                    Retrievals ({selectedQueryPlan.querySummary.totalRetrievals}
-                    ) :
-                  </Typography>
-                  <List dense sx={{ marginLeft: 4 }}>
-                    {Object.entries(retrievalsTypeCounts)
-                      .sort((a, b) => b[1] - a[1])
-                      .map(([key, value]) => (
-                        <ListItem key={key} disablePadding>
-                          <Box
-                            sx={{
-                              width: 12,
-                              height: 12,
-                              backgroundColor: retrievalsColors[key],
-                              marginRight: 1,
-                            }}
-                          />
-                          <ListItemText primary={`${key} : ${value}`} />
-                        </ListItem>
-                      ))}
-                  </List>
-                </Box>
-              </Box>
-            </Grid2>
-          ) : (
-            <Grid2 container spacing={2}>
-              <Box
-                sx={{
-                  border: "1px solid #ccc",
-                  padding: 2,
-                  marginTop: 2,
-                  display: "flex",
-                }}
-              >
-                <ResponsiveContainer width={300} height={300}>
-                  <PieChart>
-                    <Pie
-                      data={groupedPieDataRetrievalsTypeCounts}
-                      dataKey="value"
-                      nameKey="name"
-                      cx="50%"
-                      cy="50%"
-                      outerRadius={100}
-                      isAnimationActive={false}
-                    >
-                      {groupedPieDataRetrievalsTypeCounts.map((entry) => (
-                        <Cell key={entry.name} fill={entry.fill} />
-                      ))}
-                    </Pie>
-                  </PieChart>
-                </ResponsiveContainer>
-                <Box sx={{ marginLeft: 2, flex: 1 }}>
-                  <Typography variant="body1" fontWeight="bold">
-                    Retrievals ({selectedQueryPlan.querySummary.totalRetrievals}
-                    ) :
-                  </Typography>
-                  <List dense sx={{ marginLeft: 2 }}>
-                    {Object.entries(groupedRetrievalsTypeCounts)
-                      .sort((a, b) => b[1] - a[1])
-                      .map(([key, value]) => (
-                        <ListItem key={key} disablePadding>
-                          <Box
-                            sx={{
-                              width: 12,
-                              height: 12,
-                              backgroundColor: GROUP_COLORS[key],
-                              marginRight: 1,
-                            }}
-                          />
-                          <ListItemText primary={`${key} : ${value}`} />
-                        </ListItem>
-                      ))}
-                  </List>
-                </Box>
-              </Box>
-            </Grid2>
-          )}
-        </CardContent>
-      </Card>
-
-      {!isDataAggregated && (
+      <Grid2 container spacing={1}>
         <Card>
           <CardContent>
+            <Typography variant="h6">Elapsed timings of retrievals</Typography>
             <Grid2>
-              <Box
-                sx={{
-                  border: "1px solid #ccc",
-                  padding: 2,
-                  marginTop: 2,
-                }}
-              >
-                <Typography variant="body1" fontWeight="bold">
-                  Partial Providers (
-                  {selectedQueryPlan.querySummary?.partialProviders?.length ||
-                    0}
-                  ) :
-                </Typography>
-                {selectedQueryPlan.querySummary?.partialProviders ? (
+              <Typography>Group retrievals</Typography>
+              <Switch
+                checked={isGroupedTimings}
+                onChange={() => setIsGroupedTimings((prev) => !prev)}
+              />
+            </Grid2>
+            <Grid2 container spacing={2}>
+              {!isGroupedTimings ? (
+                <Box
+                  sx={{
+                    border: "1px solid #ccc",
+                    padding: 2,
+                    marginTop: 2,
+                    display: "flex",
+                  }}
+                >
+                  <ResponsiveContainer width={300} height={300}>
+                    <PieChart>
+                      <Pie
+                        data={pieDataElapsedTimings}
+                        dataKey="value"
+                        nameKey="name"
+                        cx="50%"
+                        cy="50%"
+                        outerRadius={100}
+                        isAnimationActive={false}
+                      >
+                        {pieDataElapsedTimings.map((entry) => (
+                          <Cell key={entry.name} fill={entry.fill} />
+                        ))}
+                      </Pie>
+                    </PieChart>
+                  </ResponsiveContainer>
+
+                  <Box sx={{ marginLeft: 2, flex: 1 }}>
+                    <Typography
+                      variant="body1"
+                      fontWeight="bold"
+                      marginBottom={1}
+                    >
+                      Elapsed timings
+                    </Typography>
+                    <Typography variant="body2" marginLeft={2}>
+                      Aggregate retrievals
+                    </Typography>
+                    <List dense sx={{ marginLeft: 4 }}>
+                      {Object.entries(aggregateRetrievalsElapsedTimings)
+                        .sort((a, b) => b[1] - a[1])
+                        .map(([key, value]) => (
+                          <ListItem key={key} disablePadding>
+                            <Box
+                              sx={{
+                                width: 12,
+                                height: 12,
+                                backgroundColor: retrievalsColors[key],
+                                marginRight: 1,
+                              }}
+                            />
+                            <ListItemText primary={`${key} : ${value} ms`} />
+                          </ListItem>
+                        ))}
+                    </List>
+                    <Typography variant="body2" marginLeft={2}>
+                      Database retrievals
+                    </Typography>
+                    <List dense sx={{ marginLeft: 4 }}>
+                      {Object.entries(databaseRetrievalsElapsedTimings)
+                        .sort((a, b) => b[1] - a[1])
+                        .map(([key, value]) => (
+                          <ListItem key={key} disablePadding>
+                            <Box
+                              sx={{
+                                width: 12,
+                                height: 12,
+                                backgroundColor: retrievalsColors[key],
+                                marginRight: 1,
+                              }}
+                            />
+                            <ListItemText primary={`${key} : ${value} ms`} />
+                          </ListItem>
+                        ))}
+                    </List>
+
+                    <Typography
+                      variant="body1"
+                      fontWeight="bold"
+                      marginBottom={1}
+                    >
+                      Elapsed timings (execution context)
+                    </Typography>
+                    <Typography variant="body2" marginLeft={2}>
+                      Aggregate
+                    </Typography>
+                    <List dense sx={{ marginLeft: 4 }}>
+                      {Object.entries(
+                        aggregateRetrievalsExecutionContextElapsedTimings,
+                      )
+                        .sort((a, b) => b[1] - a[1])
+                        .map(([key, value]) => (
+                          <ListItem key={key} disablePadding>
+                            <Box
+                              sx={{
+                                width: 12,
+                                height: 12,
+                                marginRight: 1,
+                              }}
+                            />
+                            <ListItemText primary={`${key} : ${value} ms`} />
+                          </ListItem>
+                        ))}
+                    </List>
+                    <Typography variant="body2" marginLeft={2}>
+                      Database
+                    </Typography>
+                    <List dense sx={{ marginLeft: 4 }}>
+                      {Object.entries(
+                        databaseRetrievalsExecutionContextElapsedTimings,
+                      )
+                        .sort((a, b) => b[1] - a[1])
+                        .map(([key, value]) => (
+                          <ListItem key={key} disablePadding>
+                            <Box
+                              sx={{
+                                width: 12,
+                                height: 12,
+                                marginRight: 1,
+                              }}
+                            />
+                            <ListItemText primary={`${key} : ${value} ms`} />
+                          </ListItem>
+                        ))}
+                    </List>
+                  </Box>
+                </Box>
+              ) : (
+                <Box
+                  sx={{
+                    border: "1px solid #ccc",
+                    padding: 2,
+                    marginTop: 2,
+                    display: "flex",
+                  }}
+                >
+                  <ResponsiveContainer width={300} height={300}>
+                    <PieChart>
+                      <Pie
+                        data={groupedPieDataElaspedTimings}
+                        dataKey="value"
+                        nameKey="name"
+                        cx="50%"
+                        cy="50%"
+                        outerRadius={100}
+                        isAnimationActive={false}
+                      >
+                        {groupedPieDataElaspedTimings.map((entry) => (
+                          <Cell key={entry.name} fill={entry.fill} />
+                        ))}
+                      </Pie>
+                    </PieChart>
+                  </ResponsiveContainer>
+
+                  <Box sx={{ marginLeft: 2, flex: 1 }}>
+                    <Typography
+                      variant="body1"
+                      fontWeight="bold"
+                      marginBottom={1}
+                    >
+                      Elapsed timings
+                    </Typography>
+                    <List dense sx={{ marginLeft: 2 }}>
+                      {Object.entries(groupedRetrievalsElapsedTimings)
+                        .sort((a, b) => b[1] - a[1])
+                        .map(([key, value]) => (
+                          <ListItem key={key} disablePadding>
+                            <Box
+                              sx={{
+                                width: 12,
+                                height: 12,
+                                backgroundColor: GROUP_COLORS[key],
+                                marginRight: 1,
+                              }}
+                            />
+                            <ListItemText primary={`${key} : ${value} ms`} />
+                          </ListItem>
+                        ))}
+                    </List>
+
+                    <Typography
+                      variant="body1"
+                      fontWeight="bold"
+                      marginBottom={1}
+                    >
+                      Elapsed timings (execution context)
+                    </Typography>
+                    <List dense sx={{ marginLeft: 2 }}>
+                      {Object.entries(
+                        groupedRetrievalsExecutionContextElapsedTimings,
+                      )
+                        .sort((a, b) => b[1] - a[1])
+                        .map(([key, value]) => (
+                          <ListItem key={key} disablePadding>
+                            <Box
+                              sx={{
+                                width: 12,
+                                height: 12,
+                                marginRight: 1,
+                              }}
+                            />
+                            <ListItemText primary={`${key} : ${value} ms`} />
+                          </ListItem>
+                        ))}
+                    </List>
+                  </Box>
+                </Box>
+              )}
+            </Grid2>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent>
+            <Typography variant="h6">Summary information</Typography>
+            <Grid2>
+              <Typography>Group retrievals</Typography>
+              <Switch
+                checked={isGroupedNumbers}
+                onChange={() => setIsGroupedNumbers((prev) => !prev)}
+              />
+            </Grid2>
+
+            {!isGroupedNumbers ? (
+              <Grid2 container spacing={2}>
+                <Box
+                  sx={{
+                    border: "1px solid #ccc",
+                    padding: 2,
+                    marginTop: 2,
+                    display: "flex",
+                  }}
+                >
+                  <ResponsiveContainer width={300} height={300}>
+                    <PieChart>
+                      <Pie
+                        data={pieDataRetrievalsTypeCounts}
+                        dataKey="value"
+                        nameKey="name"
+                        cx="50%"
+                        cy="50%"
+                        outerRadius={100}
+                        isAnimationActive={false}
+                      >
+                        {pieDataRetrievalsTypeCounts.map((entry) => (
+                          <Cell key={entry.name} fill={entry.fill} />
+                        ))}
+                      </Pie>
+                    </PieChart>
+                  </ResponsiveContainer>
+                  <Box sx={{ marginLeft: 2, flex: 1 }}>
+                    <Typography variant="body1" fontWeight="bold">
+                      Retrievals (
+                      {selectedQueryPlan.querySummary.totalRetrievals}) :
+                    </Typography>
+                    <List dense sx={{ marginLeft: 4 }}>
+                      {Object.entries(retrievalsTypeCounts)
+                        .sort((a, b) => b[1] - a[1])
+                        .map(([key, value]) => (
+                          <ListItem key={key} disablePadding>
+                            <Box
+                              sx={{
+                                width: 12,
+                                height: 12,
+                                backgroundColor: retrievalsColors[key],
+                                marginRight: 1,
+                              }}
+                            />
+                            <ListItemText primary={`${key} : ${value}`} />
+                          </ListItem>
+                        ))}
+                    </List>
+                  </Box>
+                </Box>
+              </Grid2>
+            ) : (
+              <Grid2 container spacing={2}>
+                <Box
+                  sx={{
+                    border: "1px solid #ccc",
+                    padding: 2,
+                    marginTop: 2,
+                    display: "flex",
+                  }}
+                >
+                  <ResponsiveContainer width={300} height={300}>
+                    <PieChart>
+                      <Pie
+                        data={groupedPieDataRetrievalsTypeCounts}
+                        dataKey="value"
+                        nameKey="name"
+                        cx="50%"
+                        cy="50%"
+                        outerRadius={100}
+                        isAnimationActive={false}
+                      >
+                        {groupedPieDataRetrievalsTypeCounts.map((entry) => (
+                          <Cell key={entry.name} fill={entry.fill} />
+                        ))}
+                      </Pie>
+                    </PieChart>
+                  </ResponsiveContainer>
+                  <Box sx={{ marginLeft: 2, flex: 1 }}>
+                    <Typography variant="body1" fontWeight="bold">
+                      Retrievals (
+                      {selectedQueryPlan.querySummary.totalRetrievals}) :
+                    </Typography>
+                    <List dense sx={{ marginLeft: 2 }}>
+                      {Object.entries(groupedRetrievalsTypeCounts)
+                        .sort((a, b) => b[1] - a[1])
+                        .map(([key, value]) => (
+                          <ListItem key={key} disablePadding>
+                            <Box
+                              sx={{
+                                width: 12,
+                                height: 12,
+                                backgroundColor: GROUP_COLORS[key],
+                                marginRight: 1,
+                              }}
+                            />
+                            <ListItemText primary={`${key} : ${value}`} />
+                          </ListItem>
+                        ))}
+                    </List>
+                  </Box>
+                </Box>
+              </Grid2>
+            )}
+          </CardContent>
+        </Card>
+      </Grid2>
+      <Grid2 container spacing={1}>
+        {!isDataAggregated && (
+          <Card>
+            <CardContent>
+              <Grid2>
+                <Box
+                  sx={{
+                    border: "1px solid #ccc",
+                    padding: 2,
+                    marginTop: 2,
+                  }}
+                >
+                  <Typography variant="body1" fontWeight="bold">
+                    Partial Providers (
+                    {selectedQueryPlan.querySummary?.partialProviders?.length ||
+                      0}
+                    ) :
+                  </Typography>
+                  {selectedQueryPlan.querySummary?.partialProviders ? (
+                    <List dense sx={{ marginLeft: 4 }}>
+                      {Object.entries(
+                        selectedQueryPlan.querySummary.partialProviders,
+                      ).map(([key, value]) => (
+                        <ListItem key={key} disablePadding>
+                          <ListItemText primary={value} />
+                        </ListItem>
+                      ))}
+                    </List>
+                  ) : (
+                    <Typography variant="body2" sx={{ marginLeft: 4 }}>
+                      No partial providers available.
+                    </Typography>
+                  )}
+                </Box>
+
+                <Box
+                  sx={{
+                    border: "1px solid #ccc",
+                    padding: 2,
+                    marginTop: 2,
+                  }}
+                >
+                  <Typography variant="body1" fontWeight="bold">
+                    Partitioning Count by Type:
+                  </Typography>
                   <List dense sx={{ marginLeft: 4 }}>
                     {Object.entries(
-                      selectedQueryPlan.querySummary.partialProviders,
+                      selectedQueryPlan.querySummary.partitioningCountByType,
                     ).map(([key, value]) => (
                       <ListItem key={key} disablePadding>
-                        <ListItemText primary={value} />
+                        <ListItemText primary={`${key} : ${value}`} />
+                      </ListItem>
+                    ))}
+                  </List>
+                </Box>
+
+                <Box
+                  sx={{
+                    border: "1px solid #ccc",
+                    padding: 2,
+                    marginTop: 2,
+                  }}
+                >
+                  <Typography variant="body1" fontWeight="bold">
+                    Result Size by Partitioning:
+                  </Typography>
+                  <List dense sx={{ marginLeft: 4 }}>
+                    {Object.entries(
+                      selectedQueryPlan.querySummary.resultSizeByPartitioning,
+                    ).map(([key, value]) => (
+                      <ListItem key={key} disablePadding>
+                        <ListItemText primary={`${key} : ${value}`} />
+                      </ListItem>
+                    ))}
+                  </List>
+                </Box>
+              </Grid2>
+            </CardContent>
+          </Card>
+        )}
+        <Card>
+          <CardContent>
+            <Grid2 container spacing={2}>
+              <Grid2>
+                <Typography variant="h6">Global timings</Typography>
+                {selectedQueryPlan.planInfo?.globalTimings ? (
+                  <List dense sx={{ marginLeft: 4 }}>
+                    {Object.entries(
+                      selectedQueryPlan.planInfo.globalTimings,
+                    ).map(([key, value]) => (
+                      <ListItem key={key} disablePadding>
+                        <ListItemText primary={`${key} : ${value} ms`} />
                       </ListItem>
                     ))}
                   </List>
                 ) : (
                   <Typography variant="body2" sx={{ marginLeft: 4 }}>
-                    No partial providers available.
+                    No global timings available.
                   </Typography>
                 )}
-              </Box>
+              </Grid2>
+            </Grid2>
+          </CardContent>
+        </Card>
 
+        <Card>
+          <CardContent>
+            <Grid2 container direction="column" spacing={2}>
+              <Grid2>
+                <Typography variant="h6">Measures</Typography>
+              </Grid2>
+              <Grid2>
+                <TextField
+                  fullWidth
+                  label="Search Measures"
+                  variant="outlined"
+                  value={searchTerm}
+                  onChange={(e) => setSearchTerm(e.target.value)}
+                />
+              </Grid2>
               <Box
                 sx={{
                   border: "1px solid #ccc",
@@ -559,44 +587,20 @@ export default function SummaryPage(): ReactElement {
                   marginTop: 2,
                 }}
               >
-                <Typography variant="body1" fontWeight="bold">
-                  Partitioning Count by Type:
-                </Typography>
-                <List dense sx={{ marginLeft: 4 }}>
-                  {Object.entries(
-                    selectedQueryPlan.querySummary.partitioningCountByType,
-                  ).map(([key, value]) => (
-                    <ListItem key={key} disablePadding>
-                      <ListItemText primary={`${key} : ${value}`} />
-                    </ListItem>
-                  ))}
-                </List>
-              </Box>
-
-              <Box
-                sx={{
-                  border: "1px solid #ccc",
-                  padding: 2,
-                  marginTop: 2,
-                }}
-              >
-                <Typography variant="body1" fontWeight="bold">
-                  Result Size by Partitioning:
-                </Typography>
-                <List dense sx={{ marginLeft: 4 }}>
-                  {Object.entries(
-                    selectedQueryPlan.querySummary.resultSizeByPartitioning,
-                  ).map(([key, value]) => (
-                    <ListItem key={key} disablePadding>
-                      <ListItemText primary={`${key} : ${value}`} />
-                    </ListItem>
-                  ))}
-                </List>
+                <Grid2>
+                  <List dense sx={{ marginLeft: 4 }}>
+                    {filteredMeasures.map(([key, value]) => (
+                      <ListItem key={key} disablePadding>
+                        <ListItemText primary={`- ${value}`} />
+                      </ListItem>
+                    ))}
+                  </List>
+                </Grid2>
               </Box>
             </Grid2>
           </CardContent>
         </Card>
-      )}
+      </Grid2>
     </Grid2>
   );
 }

--- a/app/summary/page.tsx
+++ b/app/summary/page.tsx
@@ -88,7 +88,7 @@ export default function SummaryPage(): ReactElement {
   } = pieData;
 
   return (
-    <Grid2 container spacing={2}>
+    <Grid2 container spacing={2} direction="column">
       <Grid2 container spacing={1}>
         {queryPlan.length >= 2 && (
           <Card

--- a/app/summary/page.tsx
+++ b/app/summary/page.tsx
@@ -145,6 +145,7 @@ export default function SummaryPage(): ReactElement {
                         padding: 2,
                         marginTop: 2,
                         display: "flex",
+                        width: "45vw",
                       }}
                     >
                       <ResponsiveContainer width={300} height={300}>
@@ -280,6 +281,7 @@ export default function SummaryPage(): ReactElement {
                         padding: 2,
                         marginTop: 2,
                         display: "flex",
+                        width: "45vw",
                       }}
                     >
                       <ResponsiveContainer width={300} height={300}>
@@ -375,6 +377,7 @@ export default function SummaryPage(): ReactElement {
                           padding: 2,
                           marginTop: 2,
                           display: "flex",
+                          width: "45vw",
                         }}
                       >
                         <ResponsiveContainer width={300} height={300}>
@@ -427,6 +430,7 @@ export default function SummaryPage(): ReactElement {
                           padding: 2,
                           marginTop: 2,
                           display: "flex",
+                          width: "45vw",
                         }}
                       >
                         <ResponsiveContainer width={300} height={300}>

--- a/app/summary/page.tsx
+++ b/app/summary/page.tsx
@@ -88,8 +88,8 @@ export default function SummaryPage(): ReactElement {
   } = pieData;
 
   return (
-    <Grid2 container spacing={2} direction="column">
-      <Grid2 container spacing={1}>
+    <Box width="100%">
+      <Grid2 container padding={1} spacing={1}>
         {queryPlan.length >= 2 && (
           <Card
             style={{
@@ -117,7 +117,7 @@ export default function SummaryPage(): ReactElement {
         )}
       </Grid2>
 
-      <Grid2 container spacing={1}>
+      <Grid2 container padding={1} spacing={1}>
         <Card>
           <CardContent>
             <Typography variant="h6">Elapsed timings of retrievals</Typography>
@@ -460,7 +460,7 @@ export default function SummaryPage(): ReactElement {
           </CardContent>
         </Card>
       </Grid2>
-      <Grid2 container spacing={1}>
+      <Grid2 container padding={1} spacing={1}>
         <Card>
           <CardContent>
             <Grid2 container spacing={2}>
@@ -601,6 +601,6 @@ export default function SummaryPage(): ReactElement {
           </Card>
         )}
       </Grid2>
-    </Grid2>
+    </Box>
   );
 }

--- a/app/summary/page.tsx
+++ b/app/summary/page.tsx
@@ -147,7 +147,7 @@ export default function SummaryPage(): ReactElement {
                         display: "flex",
                         width: "40vw",
                         height: "40vh",
-                        minWidth: "600px",
+                        minWidth: "670px",
                         minHeight: "500px",
                       }}
                     >
@@ -286,7 +286,7 @@ export default function SummaryPage(): ReactElement {
                         display: "flex",
                         width: "40vw",
                         height: "40vh",
-                        minWidth: "600px",
+                        minWidth: "670px",
                         minHeight: "500px",
                       }}
                     >
@@ -413,7 +413,7 @@ export default function SummaryPage(): ReactElement {
                           marginTop: 2,
                           display: "flex",
                           width: "40vw",
-                          minWidth: "600px",
+                          minWidth: "670px",
                         }}
                       >
                         <ResponsiveContainer width={250} height={250}>
@@ -467,7 +467,7 @@ export default function SummaryPage(): ReactElement {
                           marginTop: 2,
                           display: "flex",
                           width: "40vw",
-                          minWidth: "600px",
+                          minWidth: "670px",
                         }}
                       >
                         <ResponsiveContainer width={250} height={250}>

--- a/app/summary/page.tsx
+++ b/app/summary/page.tsx
@@ -126,7 +126,7 @@ export default function SummaryPage(): ReactElement {
           <CardContent>
             <Grid2 container padding={1} spacing={2}>
               {/* Pie charts*/}
-              <Grid2 container padding={1} spacing={2}>
+              <Grid2 container padding={1} spacing={2} justifyContent="center">
                 <Grid2 container padding={1} spacing={1} direction="column">
                   <Typography variant="h6">
                     Elapsed timings of retrievals :
@@ -477,7 +477,7 @@ export default function SummaryPage(): ReactElement {
                 </Grid2>
               </Grid2>
               {/* Additional information*/}
-              <Grid2 container padding={1} spacing={2}>
+              <Grid2 container padding={1} spacing={2} justifyContent="center">
                 <Grid2 container spacing={2}>
                   <Grid2>
                     <Typography variant="h6">Global timings</Typography>

--- a/app/summary/page.tsx
+++ b/app/summary/page.tsx
@@ -88,9 +88,13 @@ export default function SummaryPage(): ReactElement {
   } = pieData;
 
   return (
-    <Box width="100%">
-      <Grid2 container padding={1} spacing={1}>
-        {queryPlan.length >= 2 && (
+    <Box padding={2} width="100%">
+      <Typography variant="h4" gutterBottom>
+        Summary information
+      </Typography>
+      {/* Aggregation option, only if several pass*/}
+      {queryPlan.length >= 2 && (
+        <Grid2 container spacing={2}>
           <Card
             style={{
               backgroundColor: isDataAggregated
@@ -114,492 +118,502 @@ export default function SummaryPage(): ReactElement {
               <Typography>There are {queryPlan.length} Select Pass</Typography>
             </CardContent>
           </Card>
-        )}
-      </Grid2>
-
-      <Grid2 container padding={1} spacing={1}>
+        </Grid2>
+      )}
+      {/* General information*/}
+      <Grid2 container spacing={2} sx={{ pt: 2 }}>
         <Card>
           <CardContent>
-            <Typography variant="h6">Elapsed timings of retrievals</Typography>
-            <Grid2>
-              <Typography>Group retrievals</Typography>
-              <Switch
-                checked={isGroupedTimings}
-                onChange={() => setIsGroupedTimings((prev) => !prev)}
-              />
-            </Grid2>
-            <Grid2 container spacing={2}>
-              {!isGroupedTimings ? (
-                <Box
-                  sx={{
-                    border: "1px solid #ccc",
-                    padding: 2,
-                    marginTop: 2,
-                    display: "flex",
-                  }}
-                >
-                  <ResponsiveContainer width={300} height={300}>
-                    <PieChart>
-                      <Pie
-                        data={pieDataElapsedTimings}
-                        dataKey="value"
-                        nameKey="name"
-                        cx="50%"
-                        cy="50%"
-                        outerRadius={100}
-                        isAnimationActive={false}
-                      >
-                        {pieDataElapsedTimings.map((entry) => (
-                          <Cell key={entry.name} fill={entry.fill} />
-                        ))}
-                      </Pie>
-                    </PieChart>
-                  </ResponsiveContainer>
-
-                  <Box sx={{ marginLeft: 2, flex: 1 }}>
-                    <Typography
-                      variant="body1"
-                      fontWeight="bold"
-                      marginBottom={1}
-                    >
-                      Elapsed timings
-                    </Typography>
-                    <Typography variant="body2" marginLeft={2}>
-                      Aggregate retrievals
-                    </Typography>
-                    <List dense sx={{ marginLeft: 4 }}>
-                      {Object.entries(aggregateRetrievalsElapsedTimings)
-                        .sort((a, b) => b[1] - a[1])
-                        .map(([key, value]) => (
-                          <ListItem key={key} disablePadding>
-                            <Box
-                              sx={{
-                                width: 12,
-                                height: 12,
-                                backgroundColor: retrievalsColors[key],
-                                marginRight: 1,
-                              }}
-                            />
-                            <ListItemText primary={`${key} : ${value} ms`} />
-                          </ListItem>
-                        ))}
-                    </List>
-                    <Typography variant="body2" marginLeft={2}>
-                      Database retrievals
-                    </Typography>
-                    <List dense sx={{ marginLeft: 4 }}>
-                      {Object.entries(databaseRetrievalsElapsedTimings)
-                        .sort((a, b) => b[1] - a[1])
-                        .map(([key, value]) => (
-                          <ListItem key={key} disablePadding>
-                            <Box
-                              sx={{
-                                width: 12,
-                                height: 12,
-                                backgroundColor: retrievalsColors[key],
-                                marginRight: 1,
-                              }}
-                            />
-                            <ListItemText primary={`${key} : ${value} ms`} />
-                          </ListItem>
-                        ))}
-                    </List>
-
-                    <Typography
-                      variant="body1"
-                      fontWeight="bold"
-                      marginBottom={1}
-                    >
-                      Elapsed timings (execution context)
-                    </Typography>
-                    <Typography variant="body2" marginLeft={2}>
-                      Aggregate
-                    </Typography>
-                    <List dense sx={{ marginLeft: 4 }}>
-                      {Object.entries(
-                        aggregateRetrievalsExecutionContextElapsedTimings,
-                      )
-                        .sort((a, b) => b[1] - a[1])
-                        .map(([key, value]) => (
-                          <ListItem key={key} disablePadding>
-                            <Box
-                              sx={{
-                                width: 12,
-                                height: 12,
-                                marginRight: 1,
-                              }}
-                            />
-                            <ListItemText primary={`${key} : ${value} ms`} />
-                          </ListItem>
-                        ))}
-                    </List>
-                    <Typography variant="body2" marginLeft={2}>
-                      Database
-                    </Typography>
-                    <List dense sx={{ marginLeft: 4 }}>
-                      {Object.entries(
-                        databaseRetrievalsExecutionContextElapsedTimings,
-                      )
-                        .sort((a, b) => b[1] - a[1])
-                        .map(([key, value]) => (
-                          <ListItem key={key} disablePadding>
-                            <Box
-                              sx={{
-                                width: 12,
-                                height: 12,
-                                marginRight: 1,
-                              }}
-                            />
-                            <ListItemText primary={`${key} : ${value} ms`} />
-                          </ListItem>
-                        ))}
-                    </List>
-                  </Box>
-                </Box>
-              ) : (
-                <Box
-                  sx={{
-                    border: "1px solid #ccc",
-                    padding: 2,
-                    marginTop: 2,
-                    display: "flex",
-                  }}
-                >
-                  <ResponsiveContainer width={300} height={300}>
-                    <PieChart>
-                      <Pie
-                        data={groupedPieDataElaspedTimings}
-                        dataKey="value"
-                        nameKey="name"
-                        cx="50%"
-                        cy="50%"
-                        outerRadius={100}
-                        isAnimationActive={false}
-                      >
-                        {groupedPieDataElaspedTimings.map((entry) => (
-                          <Cell key={entry.name} fill={entry.fill} />
-                        ))}
-                      </Pie>
-                    </PieChart>
-                  </ResponsiveContainer>
-
-                  <Box sx={{ marginLeft: 2, flex: 1 }}>
-                    <Typography
-                      variant="body1"
-                      fontWeight="bold"
-                      marginBottom={1}
-                    >
-                      Elapsed timings
-                    </Typography>
-                    <List dense sx={{ marginLeft: 2 }}>
-                      {Object.entries(groupedRetrievalsElapsedTimings)
-                        .sort((a, b) => b[1] - a[1])
-                        .map(([key, value]) => (
-                          <ListItem key={key} disablePadding>
-                            <Box
-                              sx={{
-                                width: 12,
-                                height: 12,
-                                backgroundColor: GROUP_COLORS[key],
-                                marginRight: 1,
-                              }}
-                            />
-                            <ListItemText primary={`${key} : ${value} ms`} />
-                          </ListItem>
-                        ))}
-                    </List>
-
-                    <Typography
-                      variant="body1"
-                      fontWeight="bold"
-                      marginBottom={1}
-                    >
-                      Elapsed timings (execution context)
-                    </Typography>
-                    <List dense sx={{ marginLeft: 2 }}>
-                      {Object.entries(
-                        groupedRetrievalsExecutionContextElapsedTimings,
-                      )
-                        .sort((a, b) => b[1] - a[1])
-                        .map(([key, value]) => (
-                          <ListItem key={key} disablePadding>
-                            <Box
-                              sx={{
-                                width: 12,
-                                height: 12,
-                                marginRight: 1,
-                              }}
-                            />
-                            <ListItemText primary={`${key} : ${value} ms`} />
-                          </ListItem>
-                        ))}
-                    </List>
-                  </Box>
-                </Box>
-              )}
-            </Grid2>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardContent>
-            <Typography variant="h6">Summary information</Typography>
-            <Grid2>
-              <Typography>Group retrievals</Typography>
-              <Switch
-                checked={isGroupedNumbers}
-                onChange={() => setIsGroupedNumbers((prev) => !prev)}
-              />
-            </Grid2>
-
-            {!isGroupedNumbers ? (
-              <Grid2 container spacing={2}>
-                <Box
-                  sx={{
-                    border: "1px solid #ccc",
-                    padding: 2,
-                    marginTop: 2,
-                    display: "flex",
-                  }}
-                >
-                  <ResponsiveContainer width={300} height={300}>
-                    <PieChart>
-                      <Pie
-                        data={pieDataRetrievalsTypeCounts}
-                        dataKey="value"
-                        nameKey="name"
-                        cx="50%"
-                        cy="50%"
-                        outerRadius={100}
-                        isAnimationActive={false}
-                      >
-                        {pieDataRetrievalsTypeCounts.map((entry) => (
-                          <Cell key={entry.name} fill={entry.fill} />
-                        ))}
-                      </Pie>
-                    </PieChart>
-                  </ResponsiveContainer>
-                  <Box sx={{ marginLeft: 2, flex: 1 }}>
-                    <Typography variant="body1" fontWeight="bold">
-                      Retrievals (
-                      {selectedQueryPlan.querySummary.totalRetrievals}) :
-                    </Typography>
-                    <List dense sx={{ marginLeft: 4 }}>
-                      {Object.entries(retrievalsTypeCounts)
-                        .sort((a, b) => b[1] - a[1])
-                        .map(([key, value]) => (
-                          <ListItem key={key} disablePadding>
-                            <Box
-                              sx={{
-                                width: 12,
-                                height: 12,
-                                backgroundColor: retrievalsColors[key],
-                                marginRight: 1,
-                              }}
-                            />
-                            <ListItemText primary={`${key} : ${value}`} />
-                          </ListItem>
-                        ))}
-                    </List>
-                  </Box>
-                </Box>
-              </Grid2>
-            ) : (
-              <Grid2 container spacing={2}>
-                <Box
-                  sx={{
-                    border: "1px solid #ccc",
-                    padding: 2,
-                    marginTop: 2,
-                    display: "flex",
-                  }}
-                >
-                  <ResponsiveContainer width={300} height={300}>
-                    <PieChart>
-                      <Pie
-                        data={groupedPieDataRetrievalsTypeCounts}
-                        dataKey="value"
-                        nameKey="name"
-                        cx="50%"
-                        cy="50%"
-                        outerRadius={100}
-                        isAnimationActive={false}
-                      >
-                        {groupedPieDataRetrievalsTypeCounts.map((entry) => (
-                          <Cell key={entry.name} fill={entry.fill} />
-                        ))}
-                      </Pie>
-                    </PieChart>
-                  </ResponsiveContainer>
-                  <Box sx={{ marginLeft: 2, flex: 1 }}>
-                    <Typography variant="body1" fontWeight="bold">
-                      Retrievals (
-                      {selectedQueryPlan.querySummary.totalRetrievals}) :
-                    </Typography>
-                    <List dense sx={{ marginLeft: 2 }}>
-                      {Object.entries(groupedRetrievalsTypeCounts)
-                        .sort((a, b) => b[1] - a[1])
-                        .map(([key, value]) => (
-                          <ListItem key={key} disablePadding>
-                            <Box
-                              sx={{
-                                width: 12,
-                                height: 12,
-                                backgroundColor: GROUP_COLORS[key],
-                                marginRight: 1,
-                              }}
-                            />
-                            <ListItemText primary={`${key} : ${value}`} />
-                          </ListItem>
-                        ))}
-                    </List>
-                  </Box>
-                </Box>
-              </Grid2>
-            )}
-          </CardContent>
-        </Card>
-      </Grid2>
-      <Grid2 container padding={1} spacing={1}>
-        <Card>
-          <CardContent>
-            <Grid2 container spacing={2}>
-              <Grid2>
-                <Typography variant="h6">Global timings</Typography>
-                {selectedQueryPlan.planInfo?.globalTimings ? (
-                  <List dense sx={{ marginLeft: 4 }}>
-                    {Object.entries(
-                      selectedQueryPlan.planInfo.globalTimings,
-                    ).map(([key, value]) => (
-                      <ListItem key={key} disablePadding>
-                        <ListItemText primary={`${key} : ${value} ms`} />
-                      </ListItem>
-                    ))}
-                  </List>
-                ) : (
-                  <Typography variant="body2" sx={{ marginLeft: 4 }}>
-                    No global timings available.
+            <Grid2 container padding={1} spacing={2}>
+              {/* Pie charts*/}
+              <Grid2 container padding={1} spacing={2}>
+                <Grid2 container padding={1} spacing={1} direction="column">
+                  <Typography variant="h6">
+                    Elapsed timings of retrievals :
                   </Typography>
+
+                  <Typography>Group retrievals</Typography>
+                  <Switch
+                    checked={isGroupedTimings}
+                    onChange={() => setIsGroupedTimings((prev) => !prev)}
+                  />
+
+                  {!isGroupedTimings ? (
+                    <Box
+                      sx={{
+                        border: 1,
+                        padding: 2,
+                        marginTop: 2,
+                        display: "flex",
+                      }}
+                    >
+                      <ResponsiveContainer width={300} height={300}>
+                        <PieChart>
+                          <Pie
+                            data={pieDataElapsedTimings}
+                            dataKey="value"
+                            nameKey="name"
+                            cx="50%"
+                            cy="50%"
+                            outerRadius={100}
+                            isAnimationActive={false}
+                          >
+                            {pieDataElapsedTimings.map((entry) => (
+                              <Cell key={entry.name} fill={entry.fill} />
+                            ))}
+                          </Pie>
+                        </PieChart>
+                      </ResponsiveContainer>
+
+                      <Box sx={{ marginLeft: 2, flex: 1 }}>
+                        <Typography
+                          variant="body1"
+                          fontWeight="bold"
+                          marginBottom={1}
+                        >
+                          Elapsed timings
+                        </Typography>
+                        <Typography variant="body2" marginLeft={2}>
+                          Aggregate retrievals
+                        </Typography>
+                        <List dense sx={{ marginLeft: 4 }}>
+                          {Object.entries(aggregateRetrievalsElapsedTimings)
+                            .sort((a, b) => b[1] - a[1])
+                            .map(([key, value]) => (
+                              <ListItem key={key} disablePadding>
+                                <Box
+                                  sx={{
+                                    width: 12,
+                                    height: 12,
+                                    backgroundColor: retrievalsColors[key],
+                                    marginRight: 1,
+                                  }}
+                                />
+                                <ListItemText
+                                  primary={`${key} : ${value} ms`}
+                                />
+                              </ListItem>
+                            ))}
+                        </List>
+                        <Typography variant="body2" marginLeft={2}>
+                          Database retrievals
+                        </Typography>
+                        <List dense sx={{ marginLeft: 4 }}>
+                          {Object.entries(databaseRetrievalsElapsedTimings)
+                            .sort((a, b) => b[1] - a[1])
+                            .map(([key, value]) => (
+                              <ListItem key={key} disablePadding>
+                                <Box
+                                  sx={{
+                                    width: 12,
+                                    height: 12,
+                                    backgroundColor: retrievalsColors[key],
+                                    marginRight: 1,
+                                  }}
+                                />
+                                <ListItemText
+                                  primary={`${key} : ${value} ms`}
+                                />
+                              </ListItem>
+                            ))}
+                        </List>
+
+                        <Typography
+                          variant="body1"
+                          fontWeight="bold"
+                          marginBottom={1}
+                        >
+                          Elapsed timings (execution context)
+                        </Typography>
+                        <Typography variant="body2" marginLeft={2}>
+                          Aggregate
+                        </Typography>
+                        <List dense sx={{ marginLeft: 4 }}>
+                          {Object.entries(
+                            aggregateRetrievalsExecutionContextElapsedTimings,
+                          )
+                            .sort((a, b) => b[1] - a[1])
+                            .map(([key, value]) => (
+                              <ListItem key={key} disablePadding>
+                                <Box
+                                  sx={{
+                                    width: 12,
+                                    height: 12,
+                                    marginRight: 1,
+                                  }}
+                                />
+                                <ListItemText
+                                  primary={`${key} : ${value} ms`}
+                                />
+                              </ListItem>
+                            ))}
+                        </List>
+                        <Typography variant="body2" marginLeft={2}>
+                          Database
+                        </Typography>
+                        <List dense sx={{ marginLeft: 4 }}>
+                          {Object.entries(
+                            databaseRetrievalsExecutionContextElapsedTimings,
+                          )
+                            .sort((a, b) => b[1] - a[1])
+                            .map(([key, value]) => (
+                              <ListItem key={key} disablePadding>
+                                <Box
+                                  sx={{
+                                    width: 12,
+                                    height: 12,
+                                    marginRight: 1,
+                                  }}
+                                />
+                                <ListItemText
+                                  primary={`${key} : ${value} ms`}
+                                />
+                              </ListItem>
+                            ))}
+                        </List>
+                      </Box>
+                    </Box>
+                  ) : (
+                    <Box
+                      sx={{
+                        border: 1,
+                        padding: 2,
+                        marginTop: 2,
+                        display: "flex",
+                      }}
+                    >
+                      <ResponsiveContainer width={300} height={300}>
+                        <PieChart>
+                          <Pie
+                            data={groupedPieDataElaspedTimings}
+                            dataKey="value"
+                            nameKey="name"
+                            cx="50%"
+                            cy="50%"
+                            outerRadius={100}
+                            isAnimationActive={false}
+                          >
+                            {groupedPieDataElaspedTimings.map((entry) => (
+                              <Cell key={entry.name} fill={entry.fill} />
+                            ))}
+                          </Pie>
+                        </PieChart>
+                      </ResponsiveContainer>
+
+                      <Box sx={{ marginLeft: 2, flex: 1 }}>
+                        <Typography
+                          variant="body1"
+                          fontWeight="bold"
+                          marginBottom={1}
+                        >
+                          Elapsed timings
+                        </Typography>
+                        <List dense sx={{ marginLeft: 2 }}>
+                          {Object.entries(groupedRetrievalsElapsedTimings)
+                            .sort((a, b) => b[1] - a[1])
+                            .map(([key, value]) => (
+                              <ListItem key={key} disablePadding>
+                                <Box
+                                  sx={{
+                                    width: 12,
+                                    height: 12,
+                                    backgroundColor: GROUP_COLORS[key],
+                                    marginRight: 1,
+                                  }}
+                                />
+                                <ListItemText
+                                  primary={`${key} : ${value} ms`}
+                                />
+                              </ListItem>
+                            ))}
+                        </List>
+
+                        <Typography
+                          variant="body1"
+                          fontWeight="bold"
+                          marginBottom={1}
+                        >
+                          Elapsed timings (execution context)
+                        </Typography>
+                        <List dense sx={{ marginLeft: 2 }}>
+                          {Object.entries(
+                            groupedRetrievalsExecutionContextElapsedTimings,
+                          )
+                            .sort((a, b) => b[1] - a[1])
+                            .map(([key, value]) => (
+                              <ListItem key={key} disablePadding>
+                                <Box
+                                  sx={{
+                                    width: 12,
+                                    height: 12,
+                                    marginRight: 1,
+                                  }}
+                                />
+                                <ListItemText
+                                  primary={`${key} : ${value} ms`}
+                                />
+                              </ListItem>
+                            ))}
+                        </List>
+                      </Box>
+                    </Box>
+                  )}
+                </Grid2>
+                <Grid2 container padding={1} spacing={1} direction="column">
+                  <Typography variant="h6">Number of retrievals : </Typography>
+                  <Typography>Group retrievals</Typography>
+                  <Switch
+                    checked={isGroupedNumbers}
+                    onChange={() => setIsGroupedNumbers((prev) => !prev)}
+                  />
+
+                  {!isGroupedNumbers ? (
+                    <Grid2 container spacing={2}>
+                      <Box
+                        sx={{
+                          border: 1,
+                          padding: 2,
+                          marginTop: 2,
+                          display: "flex",
+                        }}
+                      >
+                        <ResponsiveContainer width={300} height={300}>
+                          <PieChart>
+                            <Pie
+                              data={pieDataRetrievalsTypeCounts}
+                              dataKey="value"
+                              nameKey="name"
+                              cx="50%"
+                              cy="50%"
+                              outerRadius={100}
+                              isAnimationActive={false}
+                            >
+                              {pieDataRetrievalsTypeCounts.map((entry) => (
+                                <Cell key={entry.name} fill={entry.fill} />
+                              ))}
+                            </Pie>
+                          </PieChart>
+                        </ResponsiveContainer>
+                        <Box sx={{ marginLeft: 2, flex: 1 }}>
+                          <Typography variant="body1" fontWeight="bold">
+                            Retrievals (
+                            {selectedQueryPlan.querySummary.totalRetrievals}) :
+                          </Typography>
+                          <List dense sx={{ marginLeft: 4 }}>
+                            {Object.entries(retrievalsTypeCounts)
+                              .sort((a, b) => b[1] - a[1])
+                              .map(([key, value]) => (
+                                <ListItem key={key} disablePadding>
+                                  <Box
+                                    sx={{
+                                      width: 12,
+                                      height: 12,
+                                      backgroundColor: retrievalsColors[key],
+                                      marginRight: 1,
+                                    }}
+                                  />
+                                  <ListItemText primary={`${key} : ${value}`} />
+                                </ListItem>
+                              ))}
+                          </List>
+                        </Box>
+                      </Box>
+                    </Grid2>
+                  ) : (
+                    <Grid2 container spacing={2}>
+                      <Box
+                        sx={{
+                          border: 1,
+                          padding: 2,
+                          marginTop: 2,
+                          display: "flex",
+                        }}
+                      >
+                        <ResponsiveContainer width={300} height={300}>
+                          <PieChart>
+                            <Pie
+                              data={groupedPieDataRetrievalsTypeCounts}
+                              dataKey="value"
+                              nameKey="name"
+                              cx="50%"
+                              cy="50%"
+                              outerRadius={100}
+                              isAnimationActive={false}
+                            >
+                              {groupedPieDataRetrievalsTypeCounts.map(
+                                (entry) => (
+                                  <Cell key={entry.name} fill={entry.fill} />
+                                ),
+                              )}
+                            </Pie>
+                          </PieChart>
+                        </ResponsiveContainer>
+                        <Box sx={{ marginLeft: 2, flex: 1 }}>
+                          <Typography variant="body1" fontWeight="bold">
+                            Retrievals (
+                            {selectedQueryPlan.querySummary.totalRetrievals}) :
+                          </Typography>
+                          <List dense sx={{ marginLeft: 2 }}>
+                            {Object.entries(groupedRetrievalsTypeCounts)
+                              .sort((a, b) => b[1] - a[1])
+                              .map(([key, value]) => (
+                                <ListItem key={key} disablePadding>
+                                  <Box
+                                    sx={{
+                                      width: 12,
+                                      height: 12,
+                                      backgroundColor: GROUP_COLORS[key],
+                                      marginRight: 1,
+                                    }}
+                                  />
+                                  <ListItemText primary={`${key} : ${value}`} />
+                                </ListItem>
+                              ))}
+                          </List>
+                        </Box>
+                      </Box>
+                    </Grid2>
+                  )}
+                </Grid2>
+              </Grid2>
+              {/* Additional information*/}
+              <Grid2 container padding={1} spacing={2}>
+                <Grid2 container spacing={2}>
+                  <Grid2>
+                    <Typography variant="h6">Global timings</Typography>
+                    {selectedQueryPlan.planInfo?.globalTimings ? (
+                      <List dense sx={{ marginLeft: 4 }}>
+                        {Object.entries(
+                          selectedQueryPlan.planInfo.globalTimings,
+                        ).map(([key, value]) => (
+                          <ListItem key={key} disablePadding>
+                            <ListItemText primary={`${key} : ${value} ms`} />
+                          </ListItem>
+                        ))}
+                      </List>
+                    ) : (
+                      <Typography variant="body2" sx={{ marginLeft: 4 }}>
+                        No global timings available.
+                      </Typography>
+                    )}
+                  </Grid2>
+                </Grid2>
+
+                <Grid2 container direction="column" spacing={2}>
+                  <Grid2>
+                    <Typography variant="h6">Measures</Typography>
+                  </Grid2>
+                  <Grid2>
+                    <TextField
+                      fullWidth
+                      label="Search Measures"
+                      variant="outlined"
+                      value={searchTerm}
+                      onChange={(e) => setSearchTerm(e.target.value)}
+                    />
+                  </Grid2>
+                  <Box
+                    sx={{
+                      border: "1px solid #ccc",
+                      padding: 2,
+                      marginTop: 2,
+                    }}
+                  >
+                    <Grid2>
+                      <List dense sx={{ marginLeft: 4 }}>
+                        {filteredMeasures.map(([key, value]) => (
+                          <ListItem key={key} disablePadding>
+                            <ListItemText primary={`- ${value}`} />
+                          </ListItem>
+                        ))}
+                      </List>
+                    </Grid2>
+                  </Box>
+                </Grid2>
+                {!isDataAggregated && (
+                  <Grid2>
+                    <Grid2>
+                      <Typography variant="h6">More information</Typography>
+                    </Grid2>
+                    <Box
+                      sx={{
+                        border: "1px solid #ccc",
+                        padding: 2,
+                        marginTop: 2,
+                      }}
+                    >
+                      <Typography variant="body1" fontWeight="bold">
+                        Partial Providers (
+                        {selectedQueryPlan.querySummary?.partialProviders
+                          ?.length || 0}
+                        ) :
+                      </Typography>
+                      {selectedQueryPlan.querySummary?.partialProviders ? (
+                        <List dense sx={{ marginLeft: 4 }}>
+                          {Object.entries(
+                            selectedQueryPlan.querySummary.partialProviders,
+                          ).map(([key, value]) => (
+                            <ListItem key={key} disablePadding>
+                              <ListItemText primary={value} />
+                            </ListItem>
+                          ))}
+                        </List>
+                      ) : (
+                        <Typography variant="body2" sx={{ marginLeft: 4 }}>
+                          No partial providers available.
+                        </Typography>
+                      )}
+                    </Box>
+
+                    <Box
+                      sx={{
+                        border: "1px solid #ccc",
+                        padding: 2,
+                        marginTop: 2,
+                      }}
+                    >
+                      <Typography variant="body1" fontWeight="bold">
+                        Partitioning Count by Type:
+                      </Typography>
+                      <List dense sx={{ marginLeft: 4 }}>
+                        {Object.entries(
+                          selectedQueryPlan.querySummary
+                            .partitioningCountByType,
+                        ).map(([key, value]) => (
+                          <ListItem key={key} disablePadding>
+                            <ListItemText primary={`${key} : ${value}`} />
+                          </ListItem>
+                        ))}
+                      </List>
+                    </Box>
+
+                    <Box
+                      sx={{
+                        border: "1px solid #ccc",
+                        padding: 2,
+                        marginTop: 2,
+                      }}
+                    >
+                      <Typography variant="body1" fontWeight="bold">
+                        Result Size by Partitioning:
+                      </Typography>
+                      <List dense sx={{ marginLeft: 4 }}>
+                        {Object.entries(
+                          selectedQueryPlan.querySummary
+                            .resultSizeByPartitioning,
+                        ).map(([key, value]) => (
+                          <ListItem key={key} disablePadding>
+                            <ListItemText primary={`${key} : ${value}`} />
+                          </ListItem>
+                        ))}
+                      </List>
+                    </Box>
+                  </Grid2>
                 )}
               </Grid2>
             </Grid2>
           </CardContent>
         </Card>
-
-        <Card>
-          <CardContent>
-            <Grid2 container direction="column" spacing={2}>
-              <Grid2>
-                <Typography variant="h6">Measures</Typography>
-              </Grid2>
-              <Grid2>
-                <TextField
-                  fullWidth
-                  label="Search Measures"
-                  variant="outlined"
-                  value={searchTerm}
-                  onChange={(e) => setSearchTerm(e.target.value)}
-                />
-              </Grid2>
-              <Box
-                sx={{
-                  border: "1px solid #ccc",
-                  padding: 2,
-                  marginTop: 2,
-                }}
-              >
-                <Grid2>
-                  <List dense sx={{ marginLeft: 4 }}>
-                    {filteredMeasures.map(([key, value]) => (
-                      <ListItem key={key} disablePadding>
-                        <ListItemText primary={`- ${value}`} />
-                      </ListItem>
-                    ))}
-                  </List>
-                </Grid2>
-              </Box>
-            </Grid2>
-          </CardContent>
-        </Card>
-        {!isDataAggregated && (
-          <Card>
-            <CardContent>
-              <Grid2>
-                <Box
-                  sx={{
-                    border: "1px solid #ccc",
-                    padding: 2,
-                    marginTop: 2,
-                  }}
-                >
-                  <Typography variant="body1" fontWeight="bold">
-                    Partial Providers (
-                    {selectedQueryPlan.querySummary?.partialProviders?.length ||
-                      0}
-                    ) :
-                  </Typography>
-                  {selectedQueryPlan.querySummary?.partialProviders ? (
-                    <List dense sx={{ marginLeft: 4 }}>
-                      {Object.entries(
-                        selectedQueryPlan.querySummary.partialProviders,
-                      ).map(([key, value]) => (
-                        <ListItem key={key} disablePadding>
-                          <ListItemText primary={value} />
-                        </ListItem>
-                      ))}
-                    </List>
-                  ) : (
-                    <Typography variant="body2" sx={{ marginLeft: 4 }}>
-                      No partial providers available.
-                    </Typography>
-                  )}
-                </Box>
-
-                <Box
-                  sx={{
-                    border: "1px solid #ccc",
-                    padding: 2,
-                    marginTop: 2,
-                  }}
-                >
-                  <Typography variant="body1" fontWeight="bold">
-                    Partitioning Count by Type:
-                  </Typography>
-                  <List dense sx={{ marginLeft: 4 }}>
-                    {Object.entries(
-                      selectedQueryPlan.querySummary.partitioningCountByType,
-                    ).map(([key, value]) => (
-                      <ListItem key={key} disablePadding>
-                        <ListItemText primary={`${key} : ${value}`} />
-                      </ListItem>
-                    ))}
-                  </List>
-                </Box>
-
-                <Box
-                  sx={{
-                    border: "1px solid #ccc",
-                    padding: 2,
-                    marginTop: 2,
-                  }}
-                >
-                  <Typography variant="body1" fontWeight="bold">
-                    Result Size by Partitioning:
-                  </Typography>
-                  <List dense sx={{ marginLeft: 4 }}>
-                    {Object.entries(
-                      selectedQueryPlan.querySummary.resultSizeByPartitioning,
-                    ).map(([key, value]) => (
-                      <ListItem key={key} disablePadding>
-                        <ListItemText primary={`${key} : ${value}`} />
-                      </ListItem>
-                    ))}
-                  </List>
-                </Box>
-              </Grid2>
-            </CardContent>
-          </Card>
-        )}
       </Grid2>
     </Box>
   );

--- a/app/summary/page.tsx
+++ b/app/summary/page.tsx
@@ -125,11 +125,11 @@ export default function SummaryPage(): ReactElement {
         <Card>
           <CardContent>
             <Grid2 container padding={1} spacing={2}>
-              {/* Pie charts*/}
+              {/* Line 1*/}
               <Grid2 container padding={1} spacing={2} justifyContent="center">
                 <Grid2 container padding={1} spacing={1} direction="column">
                   <Typography variant="h6">
-                    Elapsed timings of retrievals :
+                    Elapsed timings of retrievals
                   </Typography>
 
                   <Typography>Group retrievals</Typography>
@@ -146,7 +146,9 @@ export default function SummaryPage(): ReactElement {
                         marginTop: 2,
                         display: "flex",
                         width: "40vw",
+                        height: "40vh",
                         minWidth: "600px",
+                        minHeight: "500px",
                       }}
                     >
                       <ResponsiveContainer width={250} height={250}>
@@ -283,7 +285,9 @@ export default function SummaryPage(): ReactElement {
                         marginTop: 2,
                         display: "flex",
                         width: "40vw",
+                        height: "40vh",
                         minWidth: "600px",
+                        minHeight: "500px",
                       }}
                     >
                       <ResponsiveContainer width={250} height={250}>
@@ -363,8 +367,37 @@ export default function SummaryPage(): ReactElement {
                     </Box>
                   )}
                 </Grid2>
+                <Grid2 padding={1}>
+                  <Typography variant="h6">Global timings</Typography>
+                  {selectedQueryPlan.planInfo?.globalTimings ? (
+                    <Box
+                      sx={{
+                        border: "1px solid #ccc",
+                        padding: 2,
+                        marginTop: 2,
+                      }}
+                    >
+                      <List dense sx={{ marginLeft: 4 }}>
+                        {Object.entries(
+                          selectedQueryPlan.planInfo.globalTimings,
+                        ).map(([key, value]) => (
+                          <ListItem key={key} disablePadding>
+                            <ListItemText primary={`${key} : ${value} ms`} />
+                          </ListItem>
+                        ))}
+                      </List>
+                    </Box>
+                  ) : (
+                    <Typography variant="body2" sx={{ marginLeft: 4 }}>
+                      No global timings available.
+                    </Typography>
+                  )}
+                </Grid2>
+              </Grid2>
+              {/* Line 2*/}
+              <Grid2 container padding={1} spacing={2} justifyContent="center">
                 <Grid2 container padding={1} spacing={1} direction="column">
-                  <Typography variant="h6">Number of retrievals : </Typography>
+                  <Typography variant="h6">Number of retrievals</Typography>
                   <Typography>Group retrievals</Typography>
                   <Switch
                     checked={isGroupedNumbers}
@@ -483,30 +516,6 @@ export default function SummaryPage(): ReactElement {
                     </Grid2>
                   )}
                 </Grid2>
-              </Grid2>
-              {/* Additional information*/}
-              <Grid2 container padding={1} spacing={2} justifyContent="center">
-                <Grid2 container spacing={2}>
-                  <Grid2>
-                    <Typography variant="h6">Global timings</Typography>
-                    {selectedQueryPlan.planInfo?.globalTimings ? (
-                      <List dense sx={{ marginLeft: 4 }}>
-                        {Object.entries(
-                          selectedQueryPlan.planInfo.globalTimings,
-                        ).map(([key, value]) => (
-                          <ListItem key={key} disablePadding>
-                            <ListItemText primary={`${key} : ${value} ms`} />
-                          </ListItem>
-                        ))}
-                      </List>
-                    ) : (
-                      <Typography variant="body2" sx={{ marginLeft: 4 }}>
-                        No global timings available.
-                      </Typography>
-                    )}
-                  </Grid2>
-                </Grid2>
-
                 <Grid2 container direction="column" spacing={2}>
                   <Grid2>
                     <Typography variant="h6">Measures</Typography>
@@ -527,98 +536,98 @@ export default function SummaryPage(): ReactElement {
                       marginTop: 2,
                     }}
                   >
-                    <Grid2>
-                      <List dense sx={{ marginLeft: 4 }}>
-                        {filteredMeasures.map(([key, value]) => (
-                          <ListItem key={key} disablePadding>
-                            <ListItemText primary={`- ${value}`} />
-                          </ListItem>
-                        ))}
-                      </List>
-                    </Grid2>
+                    <List dense sx={{ marginLeft: 4 }}>
+                      {filteredMeasures.map(([key, value]) => (
+                        <ListItem key={key} disablePadding>
+                          <ListItemText primary={`- ${value}`} />
+                        </ListItem>
+                      ))}
+                    </List>
                   </Box>
                 </Grid2>
-                {!isDataAggregated && (
-                  <Grid2>
-                    <Grid2>
-                      <Typography variant="h6">More information</Typography>
-                    </Grid2>
-                    <Box
-                      sx={{
-                        border: "1px solid #ccc",
-                        padding: 2,
-                        marginTop: 2,
-                      }}
-                    >
-                      <Typography variant="body1" fontWeight="bold">
-                        Partial Providers (
-                        {selectedQueryPlan.querySummary?.partialProviders
-                          ?.length || 0}
-                        ) :
-                      </Typography>
-                      {selectedQueryPlan.querySummary?.partialProviders ? (
-                        <List dense sx={{ marginLeft: 4 }}>
-                          {Object.entries(
-                            selectedQueryPlan.querySummary.partialProviders,
-                          ).map(([key, value]) => (
-                            <ListItem key={key} disablePadding>
-                              <ListItemText primary={value} />
-                            </ListItem>
-                          ))}
-                        </List>
-                      ) : (
-                        <Typography variant="body2" sx={{ marginLeft: 4 }}>
-                          No partial providers available.
-                        </Typography>
-                      )}
-                    </Box>
-
-                    <Box
-                      sx={{
-                        border: "1px solid #ccc",
-                        padding: 2,
-                        marginTop: 2,
-                      }}
-                    >
-                      <Typography variant="body1" fontWeight="bold">
-                        Partitioning Count by Type:
-                      </Typography>
-                      <List dense sx={{ marginLeft: 4 }}>
-                        {Object.entries(
-                          selectedQueryPlan.querySummary
-                            .partitioningCountByType,
-                        ).map(([key, value]) => (
-                          <ListItem key={key} disablePadding>
-                            <ListItemText primary={`${key} : ${value}`} />
-                          </ListItem>
-                        ))}
-                      </List>
-                    </Box>
-
-                    <Box
-                      sx={{
-                        border: "1px solid #ccc",
-                        padding: 2,
-                        marginTop: 2,
-                      }}
-                    >
-                      <Typography variant="body1" fontWeight="bold">
-                        Result Size by Partitioning:
-                      </Typography>
-                      <List dense sx={{ marginLeft: 4 }}>
-                        {Object.entries(
-                          selectedQueryPlan.querySummary
-                            .resultSizeByPartitioning,
-                        ).map(([key, value]) => (
-                          <ListItem key={key} disablePadding>
-                            <ListItemText primary={`${key} : ${value}`} />
-                          </ListItem>
-                        ))}
-                      </List>
-                    </Box>
-                  </Grid2>
-                )}
               </Grid2>
+              {/* Line 3*/}
+
+              {!isDataAggregated && (
+                <Grid2
+                  container
+                  padding={1}
+                  spacing={2}
+                  justifyContent="center"
+                >
+                  <Box
+                    sx={{
+                      border: "1px solid #ccc",
+                      padding: 2,
+                      marginTop: 2,
+                    }}
+                  >
+                    <Typography variant="body1" fontWeight="bold">
+                      Partial Providers (
+                      {selectedQueryPlan.querySummary?.partialProviders
+                        ?.length || 0}
+                      ) :
+                    </Typography>
+                    {selectedQueryPlan.querySummary?.partialProviders ? (
+                      <List dense sx={{ marginLeft: 4 }}>
+                        {Object.entries(
+                          selectedQueryPlan.querySummary.partialProviders,
+                        ).map(([key, value]) => (
+                          <ListItem key={key} disablePadding>
+                            <ListItemText primary={value} />
+                          </ListItem>
+                        ))}
+                      </List>
+                    ) : (
+                      <Typography variant="body2" sx={{ marginLeft: 4 }}>
+                        No partial providers available.
+                      </Typography>
+                    )}
+                  </Box>
+
+                  <Box
+                    sx={{
+                      border: "1px solid #ccc",
+                      padding: 2,
+                      marginTop: 2,
+                    }}
+                  >
+                    <Typography variant="body1" fontWeight="bold">
+                      Partitioning Count by Type:
+                    </Typography>
+                    <List dense sx={{ marginLeft: 4 }}>
+                      {Object.entries(
+                        selectedQueryPlan.querySummary.partitioningCountByType,
+                      ).map(([key, value]) => (
+                        <ListItem key={key} disablePadding>
+                          <ListItemText primary={`${key} : ${value}`} />
+                        </ListItem>
+                      ))}
+                    </List>
+                  </Box>
+
+                  <Box
+                    sx={{
+                      border: "1px solid #ccc",
+                      padding: 2,
+                      marginTop: 2,
+                    }}
+                  >
+                    <Typography variant="body1" fontWeight="bold">
+                      Result Size by Partitioning:
+                    </Typography>
+                    <List dense sx={{ marginLeft: 4 }}>
+                      {Object.entries(
+                        selectedQueryPlan.querySummary.resultSizeByPartitioning,
+                      ).map(([key, value]) => (
+                        <ListItem key={key} disablePadding>
+                          <ListItemText primary={`${key} : ${value}`} />
+                        </ListItem>
+                      ))}
+                    </List>
+                  </Box>
+                </Grid2>
+              )}
             </Grid2>
           </CardContent>
         </Card>

--- a/app/summary/page.tsx
+++ b/app/summary/page.tsx
@@ -145,7 +145,7 @@ export default function SummaryPage(): ReactElement {
                         padding: 2,
                         marginTop: 2,
                         display: "flex",
-                        width: "45vw",
+                        width: "40vw",
                       }}
                     >
                       <ResponsiveContainer width={300} height={300}>
@@ -281,7 +281,7 @@ export default function SummaryPage(): ReactElement {
                         padding: 2,
                         marginTop: 2,
                         display: "flex",
-                        width: "45vw",
+                        width: "40vw",
                       }}
                     >
                       <ResponsiveContainer width={300} height={300}>
@@ -377,7 +377,7 @@ export default function SummaryPage(): ReactElement {
                           padding: 2,
                           marginTop: 2,
                           display: "flex",
-                          width: "45vw",
+                          width: "40vw",
                         }}
                       >
                         <ResponsiveContainer width={300} height={300}>
@@ -430,7 +430,7 @@ export default function SummaryPage(): ReactElement {
                           padding: 2,
                           marginTop: 2,
                           display: "flex",
-                          width: "45vw",
+                          width: "40vw",
                         }}
                       >
                         <ResponsiveContainer width={300} height={300}>

--- a/app/summary/page.tsx
+++ b/app/summary/page.tsx
@@ -461,6 +461,66 @@ export default function SummaryPage(): ReactElement {
         </Card>
       </Grid2>
       <Grid2 container spacing={1}>
+        <Card>
+          <CardContent>
+            <Grid2 container spacing={2}>
+              <Grid2>
+                <Typography variant="h6">Global timings</Typography>
+                {selectedQueryPlan.planInfo?.globalTimings ? (
+                  <List dense sx={{ marginLeft: 4 }}>
+                    {Object.entries(
+                      selectedQueryPlan.planInfo.globalTimings,
+                    ).map(([key, value]) => (
+                      <ListItem key={key} disablePadding>
+                        <ListItemText primary={`${key} : ${value} ms`} />
+                      </ListItem>
+                    ))}
+                  </List>
+                ) : (
+                  <Typography variant="body2" sx={{ marginLeft: 4 }}>
+                    No global timings available.
+                  </Typography>
+                )}
+              </Grid2>
+            </Grid2>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent>
+            <Grid2 container direction="column" spacing={2}>
+              <Grid2>
+                <Typography variant="h6">Measures</Typography>
+              </Grid2>
+              <Grid2>
+                <TextField
+                  fullWidth
+                  label="Search Measures"
+                  variant="outlined"
+                  value={searchTerm}
+                  onChange={(e) => setSearchTerm(e.target.value)}
+                />
+              </Grid2>
+              <Box
+                sx={{
+                  border: "1px solid #ccc",
+                  padding: 2,
+                  marginTop: 2,
+                }}
+              >
+                <Grid2>
+                  <List dense sx={{ marginLeft: 4 }}>
+                    {filteredMeasures.map(([key, value]) => (
+                      <ListItem key={key} disablePadding>
+                        <ListItemText primary={`- ${value}`} />
+                      </ListItem>
+                    ))}
+                  </List>
+                </Grid2>
+              </Box>
+            </Grid2>
+          </CardContent>
+        </Card>
         {!isDataAggregated && (
           <Card>
             <CardContent>
@@ -540,66 +600,6 @@ export default function SummaryPage(): ReactElement {
             </CardContent>
           </Card>
         )}
-        <Card>
-          <CardContent>
-            <Grid2 container spacing={2}>
-              <Grid2>
-                <Typography variant="h6">Global timings</Typography>
-                {selectedQueryPlan.planInfo?.globalTimings ? (
-                  <List dense sx={{ marginLeft: 4 }}>
-                    {Object.entries(
-                      selectedQueryPlan.planInfo.globalTimings,
-                    ).map(([key, value]) => (
-                      <ListItem key={key} disablePadding>
-                        <ListItemText primary={`${key} : ${value} ms`} />
-                      </ListItem>
-                    ))}
-                  </List>
-                ) : (
-                  <Typography variant="body2" sx={{ marginLeft: 4 }}>
-                    No global timings available.
-                  </Typography>
-                )}
-              </Grid2>
-            </Grid2>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardContent>
-            <Grid2 container direction="column" spacing={2}>
-              <Grid2>
-                <Typography variant="h6">Measures</Typography>
-              </Grid2>
-              <Grid2>
-                <TextField
-                  fullWidth
-                  label="Search Measures"
-                  variant="outlined"
-                  value={searchTerm}
-                  onChange={(e) => setSearchTerm(e.target.value)}
-                />
-              </Grid2>
-              <Box
-                sx={{
-                  border: "1px solid #ccc",
-                  padding: 2,
-                  marginTop: 2,
-                }}
-              >
-                <Grid2>
-                  <List dense sx={{ marginLeft: 4 }}>
-                    {filteredMeasures.map(([key, value]) => (
-                      <ListItem key={key} disablePadding>
-                        <ListItemText primary={`- ${value}`} />
-                      </ListItem>
-                    ))}
-                  </List>
-                </Grid2>
-              </Box>
-            </Grid2>
-          </CardContent>
-        </Card>
       </Grid2>
     </Grid2>
   );

--- a/app/summary/page.tsx
+++ b/app/summary/page.tsx
@@ -146,6 +146,7 @@ export default function SummaryPage(): ReactElement {
                         marginTop: 2,
                         display: "flex",
                         width: "40vw",
+                        minWidth: "600px",
                       }}
                     >
                       <ResponsiveContainer width={250} height={250}>
@@ -282,6 +283,7 @@ export default function SummaryPage(): ReactElement {
                         marginTop: 2,
                         display: "flex",
                         width: "40vw",
+                        minWidth: "600px",
                       }}
                     >
                       <ResponsiveContainer width={250} height={250}>
@@ -378,6 +380,7 @@ export default function SummaryPage(): ReactElement {
                           marginTop: 2,
                           display: "flex",
                           width: "40vw",
+                          minWidth: "600px",
                         }}
                       >
                         <ResponsiveContainer width={250} height={250}>
@@ -431,6 +434,7 @@ export default function SummaryPage(): ReactElement {
                           marginTop: 2,
                           display: "flex",
                           width: "40vw",
+                          minWidth: "600px",
                         }}
                       >
                         <ResponsiveContainer width={250} height={250}>

--- a/app/summary/page.tsx
+++ b/app/summary/page.tsx
@@ -148,7 +148,7 @@ export default function SummaryPage(): ReactElement {
                         width: "40vw",
                       }}
                     >
-                      <ResponsiveContainer width={300} height={300}>
+                      <ResponsiveContainer width={250} height={250}>
                         <PieChart>
                           <Pie
                             data={pieDataElapsedTimings}
@@ -284,7 +284,7 @@ export default function SummaryPage(): ReactElement {
                         width: "40vw",
                       }}
                     >
-                      <ResponsiveContainer width={300} height={300}>
+                      <ResponsiveContainer width={250} height={250}>
                         <PieChart>
                           <Pie
                             data={groupedPieDataElaspedTimings}
@@ -380,7 +380,7 @@ export default function SummaryPage(): ReactElement {
                           width: "40vw",
                         }}
                       >
-                        <ResponsiveContainer width={300} height={300}>
+                        <ResponsiveContainer width={250} height={250}>
                           <PieChart>
                             <Pie
                               data={pieDataRetrievalsTypeCounts}
@@ -433,7 +433,7 @@ export default function SummaryPage(): ReactElement {
                           width: "40vw",
                         }}
                       >
-                        <ResponsiveContainer width={300} height={300}>
+                        <ResponsiveContainer width={250} height={250}>
                           <PieChart>
                             <Pie
                               data={groupedPieDataRetrievalsTypeCounts}

--- a/app/summary/page.tsx
+++ b/app/summary/page.tsx
@@ -88,7 +88,7 @@ export default function SummaryPage(): ReactElement {
   } = pieData;
 
   return (
-    <Box padding={2} width="100%">
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
       <Typography variant="h4" gutterBottom>
         Summary information
       </Typography>
@@ -120,19 +120,25 @@ export default function SummaryPage(): ReactElement {
           </Card>
         </Grid2>
       )}
-      {/* General information*/}
-      <Grid2 container spacing={2} sx={{ pt: 2 }}>
-        <Card>
-          <CardContent>
-            <Grid2 container padding={1} spacing={2}>
-              {/* Line 1*/}
-              <Grid2 container padding={1} spacing={2} justifyContent="center">
-                <Grid2 container padding={1} spacing={1} direction="column">
-                  <Typography variant="h6">
-                    Elapsed timings of retrievals
-                  </Typography>
-
+      {/* Principal card*/}
+      <Card>
+        <CardContent>
+          <Grid2 container padding={1} spacing={2}>
+            {/* Line 1*/}
+            <Grid2 container padding={1} spacing={2} justifyContent="center">
+              <Grid2 padding={1} spacing={1} direction="column">
+                <Typography variant="h6">
+                  Elapsed timings of retrievals
+                </Typography>
+                <Box
+                  sx={{
+                    border: "1px solid #ccc",
+                    padding: 2,
+                    marginTop: 2,
+                  }}
+                >
                   <Typography>Group retrievals</Typography>
+
                   <Switch
                     checked={isGroupedTimings}
                     onChange={() => setIsGroupedTimings((prev) => !prev)}
@@ -141,7 +147,6 @@ export default function SummaryPage(): ReactElement {
                   {!isGroupedTimings ? (
                     <Box
                       sx={{
-                        border: 1,
                         padding: 2,
                         marginTop: 2,
                         display: "flex",
@@ -280,7 +285,6 @@ export default function SummaryPage(): ReactElement {
                   ) : (
                     <Box
                       sx={{
-                        border: 1,
                         padding: 2,
                         marginTop: 2,
                         display: "flex",
@@ -366,38 +370,47 @@ export default function SummaryPage(): ReactElement {
                       </Box>
                     </Box>
                   )}
-                </Grid2>
-                <Grid2 padding={1}>
-                  <Typography variant="h6">Global timings</Typography>
-                  {selectedQueryPlan.planInfo?.globalTimings ? (
-                    <Box
-                      sx={{
-                        border: "1px solid #ccc",
-                        padding: 2,
-                        marginTop: 2,
-                      }}
-                    >
-                      <List dense sx={{ marginLeft: 4 }}>
-                        {Object.entries(
-                          selectedQueryPlan.planInfo.globalTimings,
-                        ).map(([key, value]) => (
-                          <ListItem key={key} disablePadding>
-                            <ListItemText primary={`${key} : ${value} ms`} />
-                          </ListItem>
-                        ))}
-                      </List>
-                    </Box>
-                  ) : (
-                    <Typography variant="body2" sx={{ marginLeft: 4 }}>
-                      No global timings available.
-                    </Typography>
-                  )}
-                </Grid2>
+                </Box>
               </Grid2>
-              {/* Line 2*/}
-              <Grid2 container padding={1} spacing={2} justifyContent="center">
-                <Grid2 container padding={1} spacing={1} direction="column">
-                  <Typography variant="h6">Number of retrievals</Typography>
+              <Grid2 padding={1} spacing={1}>
+                <Typography variant="h6">Global timings</Typography>
+                {selectedQueryPlan.planInfo?.globalTimings ? (
+                  <Box
+                    sx={{
+                      border: "1px solid #ccc",
+                      padding: 2,
+                      marginTop: 2,
+                    }}
+                  >
+                    <List dense sx={{ margin: 2 }}>
+                      {Object.entries(
+                        selectedQueryPlan.planInfo.globalTimings,
+                      ).map(([key, value]) => (
+                        <ListItem key={key} disablePadding>
+                          <ListItemText primary={`${key} : ${value} ms`} />
+                        </ListItem>
+                      ))}
+                    </List>
+                  </Box>
+                ) : (
+                  <Typography variant="body2" sx={{ marginLeft: 4 }}>
+                    No global timings available.
+                  </Typography>
+                )}
+              </Grid2>
+            </Grid2>
+            {/* Line 2*/}
+            <Grid2 container padding={1} spacing={2} justifyContent="center">
+              <Grid2 padding={1} spacing={1} direction="column">
+                <Typography variant="h6">Number of retrievals</Typography>
+
+                <Box
+                  sx={{
+                    border: "1px solid #ccc",
+                    padding: 2,
+                    marginTop: 2,
+                  }}
+                >
                   <Typography>Group retrievals</Typography>
                   <Switch
                     checked={isGroupedNumbers}
@@ -405,133 +418,128 @@ export default function SummaryPage(): ReactElement {
                   />
 
                   {!isGroupedNumbers ? (
-                    <Grid2 container spacing={2}>
-                      <Box
-                        sx={{
-                          border: 1,
-                          padding: 2,
-                          marginTop: 2,
-                          display: "flex",
-                          width: "40vw",
-                          minWidth: "670px",
-                        }}
-                      >
-                        <ResponsiveContainer width={250} height={250}>
-                          <PieChart>
-                            <Pie
-                              data={pieDataRetrievalsTypeCounts}
-                              dataKey="value"
-                              nameKey="name"
-                              cx="50%"
-                              cy="50%"
-                              outerRadius={100}
-                              isAnimationActive={false}
-                            >
-                              {pieDataRetrievalsTypeCounts.map((entry) => (
-                                <Cell key={entry.name} fill={entry.fill} />
-                              ))}
-                            </Pie>
-                          </PieChart>
-                        </ResponsiveContainer>
-                        <Box sx={{ marginLeft: 2, flex: 1 }}>
-                          <Typography variant="body1" fontWeight="bold">
-                            Retrievals (
-                            {selectedQueryPlan.querySummary.totalRetrievals}) :
-                          </Typography>
-                          <List dense sx={{ marginLeft: 4 }}>
-                            {Object.entries(retrievalsTypeCounts)
-                              .sort((a, b) => b[1] - a[1])
-                              .map(([key, value]) => (
-                                <ListItem key={key} disablePadding>
-                                  <Box
-                                    sx={{
-                                      width: 12,
-                                      height: 12,
-                                      backgroundColor: retrievalsColors[key],
-                                      marginRight: 1,
-                                    }}
-                                  />
-                                  <ListItemText primary={`${key} : ${value}`} />
-                                </ListItem>
-                              ))}
-                          </List>
-                        </Box>
+                    <Box
+                      sx={{
+                        padding: 2,
+                        marginTop: 2,
+                        display: "flex",
+                        width: "40vw",
+                        minWidth: "670px",
+                      }}
+                    >
+                      <ResponsiveContainer width={250} height={250}>
+                        <PieChart>
+                          <Pie
+                            data={pieDataRetrievalsTypeCounts}
+                            dataKey="value"
+                            nameKey="name"
+                            cx="50%"
+                            cy="50%"
+                            outerRadius={100}
+                            isAnimationActive={false}
+                          >
+                            {pieDataRetrievalsTypeCounts.map((entry) => (
+                              <Cell key={entry.name} fill={entry.fill} />
+                            ))}
+                          </Pie>
+                        </PieChart>
+                      </ResponsiveContainer>
+                      <Box sx={{ marginLeft: 2, flex: 1 }}>
+                        <Typography variant="body1" fontWeight="bold">
+                          Retrievals (
+                          {selectedQueryPlan.querySummary.totalRetrievals}) :
+                        </Typography>
+                        <List dense sx={{ marginLeft: 4 }}>
+                          {Object.entries(retrievalsTypeCounts)
+                            .sort((a, b) => b[1] - a[1])
+                            .map(([key, value]) => (
+                              <ListItem key={key} disablePadding>
+                                <Box
+                                  sx={{
+                                    width: 12,
+                                    height: 12,
+                                    backgroundColor: retrievalsColors[key],
+                                    marginRight: 1,
+                                  }}
+                                />
+                                <ListItemText primary={`${key} : ${value}`} />
+                              </ListItem>
+                            ))}
+                        </List>
                       </Box>
-                    </Grid2>
+                    </Box>
                   ) : (
-                    <Grid2 container spacing={2}>
-                      <Box
-                        sx={{
-                          border: 1,
-                          padding: 2,
-                          marginTop: 2,
-                          display: "flex",
-                          width: "40vw",
-                          minWidth: "670px",
-                        }}
-                      >
-                        <ResponsiveContainer width={250} height={250}>
-                          <PieChart>
-                            <Pie
-                              data={groupedPieDataRetrievalsTypeCounts}
-                              dataKey="value"
-                              nameKey="name"
-                              cx="50%"
-                              cy="50%"
-                              outerRadius={100}
-                              isAnimationActive={false}
-                            >
-                              {groupedPieDataRetrievalsTypeCounts.map(
-                                (entry) => (
-                                  <Cell key={entry.name} fill={entry.fill} />
-                                ),
-                              )}
-                            </Pie>
-                          </PieChart>
-                        </ResponsiveContainer>
-                        <Box sx={{ marginLeft: 2, flex: 1 }}>
-                          <Typography variant="body1" fontWeight="bold">
-                            Retrievals (
-                            {selectedQueryPlan.querySummary.totalRetrievals}) :
-                          </Typography>
-                          <List dense sx={{ marginLeft: 2 }}>
-                            {Object.entries(groupedRetrievalsTypeCounts)
-                              .sort((a, b) => b[1] - a[1])
-                              .map(([key, value]) => (
-                                <ListItem key={key} disablePadding>
-                                  <Box
-                                    sx={{
-                                      width: 12,
-                                      height: 12,
-                                      backgroundColor: GROUP_COLORS[key],
-                                      marginRight: 1,
-                                    }}
-                                  />
-                                  <ListItemText primary={`${key} : ${value}`} />
-                                </ListItem>
-                              ))}
-                          </List>
-                        </Box>
+                    <Box
+                      sx={{
+                        padding: 2,
+                        marginTop: 2,
+                        display: "flex",
+                        width: "40vw",
+                        minWidth: "670px",
+                      }}
+                    >
+                      <ResponsiveContainer width={250} height={250}>
+                        <PieChart>
+                          <Pie
+                            data={groupedPieDataRetrievalsTypeCounts}
+                            dataKey="value"
+                            nameKey="name"
+                            cx="50%"
+                            cy="50%"
+                            outerRadius={100}
+                            isAnimationActive={false}
+                          >
+                            {groupedPieDataRetrievalsTypeCounts.map((entry) => (
+                              <Cell key={entry.name} fill={entry.fill} />
+                            ))}
+                          </Pie>
+                        </PieChart>
+                      </ResponsiveContainer>
+                      <Box sx={{ marginLeft: 2, flex: 1 }}>
+                        <Typography variant="body1" fontWeight="bold">
+                          Retrievals (
+                          {selectedQueryPlan.querySummary.totalRetrievals}) :
+                        </Typography>
+                        <List dense sx={{ marginLeft: 2 }}>
+                          {Object.entries(groupedRetrievalsTypeCounts)
+                            .sort((a, b) => b[1] - a[1])
+                            .map(([key, value]) => (
+                              <ListItem key={key} disablePadding>
+                                <Box
+                                  sx={{
+                                    width: 12,
+                                    height: 12,
+                                    backgroundColor: GROUP_COLORS[key],
+                                    marginRight: 1,
+                                  }}
+                                />
+                                <ListItemText primary={`${key} : ${value}`} />
+                              </ListItem>
+                            ))}
+                        </List>
                       </Box>
-                    </Grid2>
+                    </Box>
                   )}
-                </Grid2>
-                <Grid2 container direction="column" spacing={2}>
-                  <Grid2>
-                    <Typography variant="h6">Measures</Typography>
-                  </Grid2>
-                  <Grid2>
-                    <TextField
-                      fullWidth
-                      label="Search Measures"
-                      variant="outlined"
-                      value={searchTerm}
-                      onChange={(e) => setSearchTerm(e.target.value)}
-                    />
-                  </Grid2>
+                </Box>
+              </Grid2>
+              <Grid2 padding={1} spacing={1} direction="column">
+                <Typography variant="h6">Measures</Typography>
+                <Box
+                  sx={{
+                    border: "1px solid #ccc",
+                    padding: 2,
+                    marginTop: 2,
+                  }}
+                >
+                  <TextField
+                    fullWidth
+                    label="Search Measures"
+                    variant="outlined"
+                    value={searchTerm}
+                    onChange={(e) => setSearchTerm(e.target.value)}
+                  />
                   <Box
                     sx={{
-                      border: "1px solid #ccc",
                       padding: 2,
                       marginTop: 2,
                     }}
@@ -544,17 +552,14 @@ export default function SummaryPage(): ReactElement {
                       ))}
                     </List>
                   </Box>
-                </Grid2>
+                </Box>
               </Grid2>
-              {/* Line 3*/}
+            </Grid2>
+            {/* Line 3*/}
 
-              {!isDataAggregated && (
-                <Grid2
-                  container
-                  padding={1}
-                  spacing={2}
-                  justifyContent="center"
-                >
+            {!isDataAggregated && (
+              <Grid2 container padding={1} spacing={2} justifyContent="center">
+                <Grid2 padding={1} spacing={1}>
                   <Box
                     sx={{
                       border: "1px solid #ccc",
@@ -584,7 +589,8 @@ export default function SummaryPage(): ReactElement {
                       </Typography>
                     )}
                   </Box>
-
+                </Grid2>
+                <Grid2 padding={1} spacing={1}>
                   <Box
                     sx={{
                       border: "1px solid #ccc",
@@ -605,7 +611,8 @@ export default function SummaryPage(): ReactElement {
                       ))}
                     </List>
                   </Box>
-
+                </Grid2>
+                <Grid2 padding={1} spacing={1}>
                   <Box
                     sx={{
                       border: "1px solid #ccc",
@@ -627,11 +634,11 @@ export default function SummaryPage(): ReactElement {
                     </List>
                   </Box>
                 </Grid2>
-              )}
-            </Grid2>
-          </CardContent>
-        </Card>
-      </Grid2>
+              </Grid2>
+            )}
+          </Grid2>
+        </CardContent>
+      </Card>
     </Box>
   );
 }


### PR DESCRIPTION
# Issue Number: #113 

Closes #113 
_The issue will be automatically closed if merged_

# Description:

Improving summary page information display

- [x] Improving page structure to minimise moves when toggles are clicked and size change
- [x] Page title size matching with "nodes" and "timeline" pages
- [x] Placing all the information in one single card, there is no need for several

# How to test:

Launch the app `yarn dev`

Go to page: summary

Check that the changes work

# Other notes:

There are a lot of changes to read since I changed the structure which moved blocks of code
I advise directly reading the page itself