### PR TITLE
Fix issue #112: loading indication

### DIFF
--- a/app/submit-query/page.tsx
+++ b/app/submit-query/page.tsx
@@ -14,6 +14,9 @@ import {
   Tooltip,
   Typography,
   Switch,
+  CircularProgress,
+  Box,
+  Fade,
 } from "@mui/material";
 import { isAxiosError } from "axios";
 import { Formik, Field, Form } from "formik";
@@ -113,7 +116,7 @@ export default function SubmitQueryPage(): ReactElement {
                 }}
                 onSubmit={handleSubmit}
               >
-                {({ setFieldValue }) => (
+                {({ setFieldValue, isSubmitting }) => (
                   <Form className="space-y-4">
                     <Field
                       as={TextField}
@@ -157,14 +160,34 @@ export default function SubmitQueryPage(): ReactElement {
                       onFileLoad={(content) => setFieldValue("text", content)}
                       label="Or upload an MDX request file (.txt)"
                     />
-
-                    <Button
-                      type="submit"
-                      variant="contained"
-                      className="w-full"
-                    >
-                      Send and receive query plan
-                    </Button>
+                    <Box position="relative">
+                      <Button
+                        type="submit"
+                        variant="contained"
+                        className="w-full"
+                        disabled={isSubmitting}
+                      >
+                        Send and receive query plan
+                      </Button>
+                      <Fade
+                        in={isSubmitting}
+                        style={{
+                          transitionDelay: isSubmitting ? "800ms" : "0ms",
+                        }}
+                        unmountOnExit
+                      >
+                        <CircularProgress
+                          size={24}
+                          sx={{
+                            position: "absolute",
+                            top: "50%",
+                            left: "50%",
+                            marginTop: "-12px",
+                            marginLeft: "-12px",
+                          }}
+                        />
+                      </Fade>
+                    </Box>
                   </Form>
                 )}
               </Formik>


### PR DESCRIPTION
# Issue Number:

Closes #112 
_The issue will be automatically closed if merged_

# Description:

Add a loading _indication_ (not message) after 800ms

# How to test:

- Launch the app `yarn dev`
- Try to send a query : as soon as you send, the button should be disabled. If it takes more than 800ms, you should see a rotating circle to indicate loading. If you can't get a long enough request, you can temporarily change the 800ms to 100ms, and you should see it.

# Other notes:
