### PR TITLE
Fix retrieval custom visual

### DIFF
--- a/components/RetrievalDialog.tsx
+++ b/components/RetrievalDialog.tsx
@@ -77,14 +77,28 @@ export function RetrievalDialog({
                   Timing Info :
                 </Typography>
                 <List>
-                  {Object.entries(retrieval.timingInfo).map(([key, values]) => (
-                    <ListItem key={key} disablePadding>
-                      <ListItemText
-                        primary={key}
-                        secondary={values.join(", ")}
-                      />
-                    </ListItem>
-                  ))}
+                  {Object.entries(retrieval.timingInfo).map(
+                    ([key, values]) =>
+                      !key.includes("elapsed") && (
+                        <ListItem key={key} disablePadding>
+                          <ListItemText
+                            primary={key}
+                            secondary={values.join(", ")}
+                          />
+                        </ListItem>
+                      ),
+                  )}
+                  {Object.entries(retrieval.timingInfo).map(
+                    ([key, values]) =>
+                      key.includes("elapsed") && (
+                        <ListItem key={key} disablePadding>
+                          <ListItemText
+                            primary={key}
+                            secondary={values.join(", ")}
+                          />
+                        </ListItem>
+                      ),
+                  )}
                 </List>
               </>
             )}

--- a/components/RetrievalDialog.tsx
+++ b/components/RetrievalDialog.tsx
@@ -104,8 +104,8 @@ export function RetrievalDialog({
                           >
                             {values
                               .map((value) => {
-                                let strValue = String(value);
-                                let diff =
+                                const strValue = String(value);
+                                const diff =
                                   maxTimingInfoLength - strValue.length;
                                 return " ".repeat(diff) + strValue;
                               })

--- a/components/RetrievalDialog.tsx
+++ b/components/RetrievalDialog.tsx
@@ -79,7 +79,7 @@ export function RetrievalDialog({
                 <List>
                   {Object.entries(retrieval.timingInfo).map(
                     ([key, values]) =>
-                      !key.includes("elapsed") && (
+                      !key.includes("executionContext") && (
                         <ListItem key={key} disablePadding>
                           <ListItemText
                             primary={key}
@@ -90,7 +90,7 @@ export function RetrievalDialog({
                   )}
                   {Object.entries(retrieval.timingInfo).map(
                     ([key, values]) =>
-                      key.includes("elapsed") && (
+                      key.includes("executionContext") && (
                         <ListItem key={key} disablePadding>
                           <ListItemText
                             primary={key}

--- a/components/RetrievalDialog.tsx
+++ b/components/RetrievalDialog.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { AggregateRetrieval, DatabaseRetrieval } from "@/lib/types";
 import { Close } from "@mui/icons-material";
 import {
@@ -12,8 +14,11 @@ import {
   ListItem,
   ListItemText,
   Divider,
+  Switch,
+  Tooltip,
+  Box,
 } from "@mui/material";
-import { type ReactElement } from "react";
+import { type ReactElement, useState } from "react";
 
 type RetrievalDialogProps = {
   retrieval: AggregateRetrieval | DatabaseRetrieval;
@@ -27,6 +32,8 @@ export function RetrievalDialog({
   setOpen,
 }: RetrievalDialogProps): ReactElement | null {
   if (!retrieval) return null;
+
+  const [areNumbersAligned, setAreNumbersAligned] = useState<boolean>(false);
 
   const isAggregate = "partialProviderName" in retrieval;
   const excludedKeys = new Set(["timingInfo", "location"]);
@@ -76,17 +83,18 @@ export function RetrievalDialog({
                   </ListItem>
                 ))}
             </List>
-
+            <Divider sx={{ marginTop: 1, marginBottom: 3 }} />
             {/* TimingInfo */}
             {"timingInfo" in retrieval && (
               <>
                 <Typography
                   variant="subtitle1"
                   gutterBottom
-                  sx={{ marginTop: 2 }}
+                  sx={{ marginTop: 2, marginRight: 2 }}
                 >
                   Timing Info :
                 </Typography>
+
                 <List>
                   {Object.entries(reorderedTimingInfo).map(([key, values]) => (
                     <ListItem key={key} disablePadding>
@@ -105,9 +113,12 @@ export function RetrievalDialog({
                             {values
                               .map((value) => {
                                 const strValue = String(value);
-                                const diff =
-                                  maxTimingInfoLength - strValue.length;
-                                return " ".repeat(diff) + strValue;
+                                if (areNumbersAligned) {
+                                  const diff =
+                                    maxTimingInfoLength - strValue.length;
+                                  return " ".repeat(diff) + strValue;
+                                }
+                                return strValue;
                               })
                               .join(", ")}
                           </Typography>
@@ -116,9 +127,16 @@ export function RetrievalDialog({
                     </ListItem>
                   ))}
                 </List>
+                <Tooltip title="Align numbers" arrow placement="right">
+                  <Switch
+                    checked={areNumbersAligned}
+                    onChange={() => setAreNumbersAligned((prev) => !prev)}
+                    sx={{ transform: "scale(0.8)" }}
+                  />
+                </Tooltip>
               </>
             )}
-
+            <Divider sx={{ marginTop: 1, marginBottom: 3 }} />
             {/* Location (only if aggregate) */}
             {isAggregate &&
               "location" in retrieval &&

--- a/components/RetrievalDialog.tsx
+++ b/components/RetrievalDialog.tsx
@@ -30,9 +30,20 @@ export function RetrievalDialog({
 
   const isAggregate = "partialProviderName" in retrieval;
   const excludedKeys = new Set(["timingInfo", "location"]);
+  const maxTimingInfoLength = String(
+    Math.max(...Object.values(retrieval.timingInfo).flat()),
+  ).length;
+  const reorderedTimingInfo = Object.fromEntries([
+    ...Object.entries(retrieval.timingInfo).filter(
+      ([key]) => !key.includes("executionContext"),
+    ),
+    ...Object.entries(retrieval.timingInfo).filter(([key]) =>
+      key.includes("executionContext"),
+    ),
+  ]); // re-ordering timingInfo for keys in wanted order
 
   return (
-    <Dialog open={open} onClose={() => setOpen(false)} maxWidth="md">
+    <Dialog open={open} onClose={() => setOpen(false)} maxWidth="lg">
       <DialogTitle>
         {isAggregate ? "Aggregate Retrieval" : "Database Retrieval"}
         <IconButton
@@ -77,28 +88,33 @@ export function RetrievalDialog({
                   Timing Info :
                 </Typography>
                 <List>
-                  {Object.entries(retrieval.timingInfo).map(
-                    ([key, values]) =>
-                      !key.includes("executionContext") && (
-                        <ListItem key={key} disablePadding>
-                          <ListItemText
-                            primary={key}
-                            secondary={values.join(", ")}
-                          />
-                        </ListItem>
-                      ),
-                  )}
-                  {Object.entries(retrieval.timingInfo).map(
-                    ([key, values]) =>
-                      key.includes("executionContext") && (
-                        <ListItem key={key} disablePadding>
-                          <ListItemText
-                            primary={key}
-                            secondary={values.join(", ")}
-                          />
-                        </ListItem>
-                      ),
-                  )}
+                  {Object.entries(reorderedTimingInfo).map(([key, values]) => (
+                    <ListItem key={key} disablePadding>
+                      <ListItemText
+                        primary={key}
+                        secondary={
+                          <Typography
+                            component="span"
+                            sx={{
+                              fontFamily: "monospace",
+                              whiteSpace: "pre",
+                              fontSize: "0.875rem",
+                              color: "lightgray",
+                            }}
+                          >
+                            {values
+                              .map((value) => {
+                                let strValue = String(value);
+                                let diff =
+                                  maxTimingInfoLength - strValue.length;
+                                return " ".repeat(diff) + strValue;
+                              })
+                              .join(", ")}
+                          </Typography>
+                        }
+                      />
+                    </ListItem>
+                  ))}
                 </List>
               </>
             )}

--- a/components/RetrievalDialog.tsx
+++ b/components/RetrievalDialog.tsx
@@ -16,7 +16,6 @@ import {
   Divider,
   Switch,
   Tooltip,
-  Box,
 } from "@mui/material";
 import { type ReactElement, useState } from "react";
 
@@ -31,9 +30,8 @@ export function RetrievalDialog({
   open,
   setOpen,
 }: RetrievalDialogProps): ReactElement | null {
-  if (!retrieval) return null;
-
   const [areNumbersAligned, setAreNumbersAligned] = useState<boolean>(false);
+  if (!retrieval) return null;
 
   const isAggregate = "partialProviderName" in retrieval;
   const excludedKeys = new Set(["timingInfo", "location"]);


### PR DESCRIPTION
# Issue Number: #128 

Closes #128 
_The issue will be automatically closed if merged_

# Description:

In the custom card that displays info about the retrieval when clicked on, on pages timeline and slowest nodes
In the TimingInfo section:

- [x] executionContext will be listed after those that are not executionContext
- [x] spaces will be added for all lines of numbers to be the same size (easier to read)

# How to test:

Launch app
Go to page timeline or slowest nodes
Click on a retrieval
Check that the features listed in description work
