### PR TITLE
Fix empty timing info bug

### DIFF
--- a/lib/functions/summary/buildSummary.ts
+++ b/lib/functions/summary/buildSummary.ts
@@ -50,10 +50,9 @@ export function buildSummary(queryPlan: QueryPlan): Summary {
 
   // Filling the records
   aggregateRetrievals.forEach(({ timingInfo, type }) => {
-    const elapsedTimeSum = timingInfo.elapsedTime.reduce(
-      (acc, num) => acc + num,
-      0,
-    );
+    const elapsedTimeSum = Object.values(timingInfo)
+      .flat()
+      .reduce((acc, num) => acc + num, 0);
 
     aggregateRetrievalsElapsedTimings[type] =
       (aggregateRetrievalsElapsedTimings[type] ?? 0) + elapsedTimeSum;
@@ -88,10 +87,10 @@ export function buildSummary(queryPlan: QueryPlan): Summary {
   });
 
   databaseRetrievals.forEach(({ timingInfo }) => {
-    const databaseRetrievalsElapsedTime = timingInfo.elapsedTime.reduce(
-      (acc, num) => acc + num,
-      0,
-    );
+    const databaseRetrievalsElapsedTime = Object.values(timingInfo)
+      .flat()
+      .reduce((acc, num) => acc + num, 0);
+
     groupedRetrievalsElapsedTimings["Database"] +=
       databaseRetrievalsElapsedTime;
     databaseRetrievalsElapsedTimings["DatabaseRetrieval"] +=

--- a/lib/functions/summary/buildSummary.ts
+++ b/lib/functions/summary/buildSummary.ts
@@ -50,9 +50,10 @@ export function buildSummary(queryPlan: QueryPlan): Summary {
 
   // Filling the records
   aggregateRetrievals.forEach(({ timingInfo, type }) => {
-    const elapsedTimeSum = Object.values(timingInfo)
-      .flat()
-      .reduce((acc, num) => acc + num, 0);
+    const elapsedTimeSum = (timingInfo.elapsedTime ?? []).reduce(
+      (acc, num) => acc + num,
+      0,
+    );
 
     aggregateRetrievalsElapsedTimings[type] =
       (aggregateRetrievalsElapsedTimings[type] ?? 0) + elapsedTimeSum;
@@ -87,10 +88,10 @@ export function buildSummary(queryPlan: QueryPlan): Summary {
   });
 
   databaseRetrievals.forEach(({ timingInfo }) => {
-    const databaseRetrievalsElapsedTime = Object.values(timingInfo)
-      .flat()
-      .reduce((acc, num) => acc + num, 0);
-
+    const databaseRetrievalsElapsedTime = (timingInfo.elapsedTime ?? []).reduce(
+      (acc, num) => acc + num,
+      0,
+    );
     groupedRetrievalsElapsedTimings["Database"] +=
       databaseRetrievalsElapsedTime;
     databaseRetrievalsElapsedTimings["DatabaseRetrieval"] +=


### PR DESCRIPTION
# Issue Number: #133 

Closes #133 
_The issue will be automatically closed if merged_

# Description:

Fixing crash when timingInfo has no key elapsedTiming

# How to test:

Load a queryPlan with a ```timingInfo": {}```
Check that it does not crash and that the calculation is still correct
