### PR TITLE
Fixing nodes crash empty timing info

### DIFF
--- a/lib/functions/slowestNodes.ts
+++ b/lib/functions/slowestNodes.ts
@@ -18,8 +18,8 @@ function computeTimingDetails(timingInfo: TimingInfo): {
   stdDevTiming: number;
   parallelCount: number;
 } {
-  const startTimes: number[] = timingInfo.startTime;
-  const elapsedTimes: number[] = timingInfo.elapsedTime;
+  const startTimes: number[] = timingInfo.startTime ?? [];
+  const elapsedTimes: number[] = timingInfo.elapsedTime ?? [];
 
   if (startTimes.length != elapsedTimes.length) {
     return {
@@ -55,30 +55,43 @@ export function getSlowestNodes(
   databaseRetrievals: DatabaseRetrieval[],
   numberOfNodes: number,
 ): ProcessedNode[] {
-  const aggregateNodes: ProcessedNode[] = aggregateRetrievals.map((node) => {
-    const { totalTiming, meanTiming, stdDevTiming, parallelCount } =
-      computeTimingDetails(node.timingInfo);
-    return {
-      id: node.retrievalId,
-      type: "Aggregate",
-      timing: totalTiming,
-      mean: meanTiming,
-      stdDev: stdDevTiming,
-      parallelCount,
-    };
-  });
-  const databaseNodes: ProcessedNode[] = databaseRetrievals.map((node) => {
-    const { totalTiming, meanTiming, stdDevTiming, parallelCount } =
-      computeTimingDetails(node.timingInfo);
-    return {
-      id: node.retrievalId,
-      type: "Database",
-      timing: totalTiming,
-      mean: meanTiming,
-      stdDev: stdDevTiming,
-      parallelCount,
-    };
-  });
+  const aggregateNodes: ProcessedNode[] = aggregateRetrievals
+    .filter(
+      (node) =>
+        node.timingInfo.startTime?.length &&
+        node.timingInfo.elapsedTime?.length,
+    )
+    .map((node) => {
+      const { totalTiming, meanTiming, stdDevTiming, parallelCount } =
+        computeTimingDetails(node.timingInfo);
+      return {
+        id: node.retrievalId,
+        type: "Aggregate",
+        timing: totalTiming,
+        mean: meanTiming,
+        stdDev: stdDevTiming,
+        parallelCount,
+      };
+    });
+
+  const databaseNodes: ProcessedNode[] = databaseRetrievals
+    .filter(
+      (node) =>
+        node.timingInfo.startTime?.length &&
+        node.timingInfo.elapsedTime?.length,
+    )
+    .map((node) => {
+      const { totalTiming, meanTiming, stdDevTiming, parallelCount } =
+        computeTimingDetails(node.timingInfo);
+      return {
+        id: node.retrievalId,
+        type: "Database",
+        timing: totalTiming,
+        mean: meanTiming,
+        stdDev: stdDevTiming,
+        parallelCount,
+      };
+    });
 
   const allNodes: ProcessedNode[] = [...aggregateNodes, ...databaseNodes];
 

--- a/lib/functions/slowestNodes.ts
+++ b/lib/functions/slowestNodes.ts
@@ -21,7 +21,10 @@ function computeTimingDetails(timingInfo: TimingInfo): {
   const startTimes: number[] = timingInfo.startTime ?? [];
   const elapsedTimes: number[] = timingInfo.elapsedTime ?? [];
 
-  if (startTimes.length != elapsedTimes.length) {
+  if (
+    (startTimes.length === 0 && elapsedTimes.length === 0) ||
+    startTimes.length != elapsedTimes.length
+  ) {
     return {
       totalTiming: 0,
       meanTiming: 0,


### PR DESCRIPTION
# Issue Number: #136 

Closes #136 
_The issue will be automatically closed if merged_

# Description:

Nodes pages crash when a retrieval gives `"timingInfo": {}`
This is something that can still happen, as I got it from a generated query plan, so it is not related to the old version and **must be fixed**

Related to #133 

The error is that the key `startTime` does not exist so `const startTimes: number[] = timingInfo.startTime;` creates something undefined
Fixed by avoiding to use timingInfo without keys in the function, and by returning all zeros if the function takes an `{}` timingInfo

# How to test:

Test with a queryPlan containing a `"timingInfo": {}` (examples in #135 ) and check that all the pages, including `Nodes`, work

# Notes:

@TimotheeVrg I modified your page
