### PR TITLE
Fix issue #129: Timeline time modes

### DIFF
--- a/app/timeline/page.tsx
+++ b/app/timeline/page.tsx
@@ -169,6 +169,13 @@ export default function TimelinePage(): ReactElement {
         >
           Fit entire timeline
         </Button>
+      </FormGroup>
+      <Grid2
+        container
+        justifyContent="space-between"
+        marginTop={2}
+        marginBottom={2}
+      >
         <FormControlLabel
           control={
             <Switch
@@ -177,19 +184,41 @@ export default function TimelinePage(): ReactElement {
             />
           }
           label="Aggregate passes on the same timeline"
+          sx={{
+            borderWidth: 1,
+            borderColor: "primary.main",
+            borderRadius: 2,
+            padding: 1,
+          }}
         />
-      </FormGroup>
-      <Grid2 container justifyContent="space-between" marginTop={2}>
-        <FormGroup row sx={{ alignItems: "center" }}>
-          <Typography variant="body2">Show type mode</Typography>
+        <FormGroup
+          row
+          sx={{
+            alignItems: "center",
+            borderWidth: 1,
+            borderColor: "primary.main",
+            borderRadius: 2,
+            padding: 1,
+          }}
+        >
+          <Typography>Show type mode</Typography>
           <Switch
             checked={timeMode}
             onChange={() => setTimeMode(!timeMode)}
             color="primary"
           />
-          <Typography variant="body2">Show time mode</Typography>
+          <Typography>Show time mode</Typography>
         </FormGroup>
-        <FormGroup row sx={{ alignItems: "center" }}>
+        <FormGroup
+          row
+          sx={{
+            alignItems: "center",
+            borderWidth: 1,
+            borderColor: "primary.main",
+            borderRadius: 2,
+            padding: 1,
+          }}
+        >
           <Typography variant="body2">Use a threshold:</Typography>
           <Input
             type="number"
@@ -220,7 +249,7 @@ export default function TimelinePage(): ReactElement {
       <Grid2
         container
         width="100%"
-        maxHeight="59vh"
+        maxHeight="51vh"
         marginTop={2}
         flexDirection="row"
         sx={{ overflowY: "auto", overflowX: "hidden" }}

--- a/app/timeline/page.tsx
+++ b/app/timeline/page.tsx
@@ -194,10 +194,21 @@ export default function TimelinePage(): ReactElement {
           <Input
             type="number"
             value={threshold}
-            onChange={(event) => setThreshold(Number(event.target.value))}
+            onChange={(event) => {
+              const value = Number(event.target.value);
+              if (value >= minDuration && value <= maxDuration)
+                setThreshold(value);
+            }}
             sx={{ width: "50px", marginX: 1 }}
           />
           <Typography variant="body2">ms</Typography>
+          <Slider
+            sx={{ width: 200, marginLeft: 2 }}
+            min={minDuration}
+            max={maxDuration}
+            value={threshold}
+            onChange={(_event, value) => setThreshold(value as number)}
+          />
         </FormGroup>
       </Grid2>
       <TimelineLegend

--- a/app/timeline/page.tsx
+++ b/app/timeline/page.tsx
@@ -34,6 +34,7 @@ export default function TimelinePage(): ReactElement {
   const [combinePasses, setCombinePasses] = useState<boolean>(false);
 
   const [showDialog, setShowDialog] = useState<boolean>(false);
+  const [timeMode, setTimeMode] = useState<boolean>(false);
   const [selectedRetrieval, setSelectedRetrieval] = useState<
     AggregateRetrieval | DatabaseRetrieval
   >(emptyAggregateRetrieval);
@@ -138,7 +139,7 @@ export default function TimelinePage(): ReactElement {
 
   const timeline = buildTimeline(aggregateRetrievals, databaseRetrievals);
 
-  const { nbCores, ...coresTimeline } = timeline;
+  const { nbCores, maxTiming, minTiming, ...coresTimeline } = timeline;
 
   // Find the maximum end time to calculate the content width
   maxEnd = Math.max(
@@ -176,7 +177,20 @@ export default function TimelinePage(): ReactElement {
           label="Aggregate passes on the same timeline"
         />
       </FormGroup>
-      <TimelineLegend />
+      <FormGroup row sx={{ alignItems: "center" }}>
+        <Typography variant="body2">Show type mode</Typography>
+        <Switch
+          checked={timeMode}
+          onChange={() => setTimeMode(!timeMode)}
+          color="primary"
+        />
+        <Typography variant="body2">Show time mode</Typography>
+      </FormGroup>
+      <TimelineLegend
+        timeMode={timeMode}
+        minTiming={minTiming}
+        maxTiming={maxTiming}
+      />
       <Grid2
         container
         width="100%"
@@ -219,6 +233,9 @@ export default function TimelinePage(): ReactElement {
                 timings={coresTimeline[index] || []}
                 scale={scale}
                 openRetrievalDialog={openRetrievalDialog}
+                timeMode={timeMode}
+                minTiming={minTiming}
+                maxTiming={maxTiming}
               />
             </TimelineDiv>
           ))}

--- a/app/timeline/page.tsx
+++ b/app/timeline/page.tsx
@@ -204,6 +204,7 @@ export default function TimelinePage(): ReactElement {
         timeMode={timeMode}
         minTiming={minTiming}
         maxTiming={maxTiming}
+        threshold={threshold}
       />
       <Grid2
         container

--- a/app/timeline/page.tsx
+++ b/app/timeline/page.tsx
@@ -141,7 +141,7 @@ export default function TimelinePage(): ReactElement {
 
   const timeline = buildTimeline(aggregateRetrievals, databaseRetrievals);
 
-  const { nbCores, maxTiming, minTiming, ...coresTimeline } = timeline;
+  const { nbCores, maxDuration, minDuration, ...coresTimeline } = timeline;
 
   // Find the maximum end time to calculate the content width
   maxEnd = Math.max(
@@ -202,8 +202,8 @@ export default function TimelinePage(): ReactElement {
       </Grid2>
       <TimelineLegend
         timeMode={timeMode}
-        minTiming={minTiming}
-        maxTiming={maxTiming}
+        minDuration={minDuration}
+        maxDuration={maxDuration}
         threshold={threshold}
       />
       <Grid2
@@ -249,8 +249,8 @@ export default function TimelinePage(): ReactElement {
                 scale={scale}
                 openRetrievalDialog={openRetrievalDialog}
                 timeMode={timeMode}
-                minTiming={minTiming}
-                maxTiming={maxTiming}
+                minDuration={minDuration}
+                maxDuration={maxDuration}
                 threshold={threshold}
               />
             </TimelineDiv>

--- a/app/timeline/page.tsx
+++ b/app/timeline/page.tsx
@@ -21,6 +21,7 @@ import {
   FormControlLabel,
   FormGroup,
   Grid2,
+  Input,
   Slider,
   Switch,
   Typography,
@@ -35,6 +36,7 @@ export default function TimelinePage(): ReactElement {
 
   const [showDialog, setShowDialog] = useState<boolean>(false);
   const [timeMode, setTimeMode] = useState<boolean>(false);
+  const [threshold, setThreshold] = useState<number>(0);
   const [selectedRetrieval, setSelectedRetrieval] = useState<
     AggregateRetrieval | DatabaseRetrieval
   >(emptyAggregateRetrieval);
@@ -177,15 +179,27 @@ export default function TimelinePage(): ReactElement {
           label="Aggregate passes on the same timeline"
         />
       </FormGroup>
-      <FormGroup row sx={{ alignItems: "center" }}>
-        <Typography variant="body2">Show type mode</Typography>
-        <Switch
-          checked={timeMode}
-          onChange={() => setTimeMode(!timeMode)}
-          color="primary"
-        />
-        <Typography variant="body2">Show time mode</Typography>
-      </FormGroup>
+      <Grid2 container justifyContent="space-between" marginTop={2}>
+        <FormGroup row sx={{ alignItems: "center" }}>
+          <Typography variant="body2">Show type mode</Typography>
+          <Switch
+            checked={timeMode}
+            onChange={() => setTimeMode(!timeMode)}
+            color="primary"
+          />
+          <Typography variant="body2">Show time mode</Typography>
+        </FormGroup>
+        <FormGroup row sx={{ alignItems: "center" }}>
+          <Typography variant="body2">Use a threshold:</Typography>
+          <Input
+            type="number"
+            value={threshold}
+            onChange={(event) => setThreshold(Number(event.target.value))}
+            sx={{ width: "50px", marginX: 1 }}
+          />
+          <Typography variant="body2">ms</Typography>
+        </FormGroup>
+      </Grid2>
       <TimelineLegend
         timeMode={timeMode}
         minTiming={minTiming}
@@ -236,6 +250,7 @@ export default function TimelinePage(): ReactElement {
                 timeMode={timeMode}
                 minTiming={minTiming}
                 maxTiming={maxTiming}
+                threshold={threshold}
               />
             </TimelineDiv>
           ))}

--- a/components/RetrievalDialog.tsx
+++ b/components/RetrievalDialog.tsx
@@ -35,7 +35,7 @@ export function RetrievalDialog({
 
   const isAggregate = "partialProviderName" in retrieval;
   const excludedKeys = new Set(["timingInfo", "location"]);
-  const maxTimingInfoLength = String(
+  const maxDurationInfoLength = String(
     Math.max(...Object.values(retrieval.timingInfo).flat()),
   ).length;
   const reorderedTimingInfo = Object.fromEntries([
@@ -113,7 +113,7 @@ export function RetrievalDialog({
                                 const strValue = String(value);
                                 if (areNumbersAligned) {
                                   const diff =
-                                    maxTimingInfoLength - strValue.length;
+                                    maxDurationInfoLength - strValue.length;
                                   return " ".repeat(diff) + strValue;
                                 }
                                 return strValue;

--- a/components/timeline/CoreProcesses.tsx
+++ b/components/timeline/CoreProcesses.tsx
@@ -1,5 +1,12 @@
-import { TIMELINE_COLORS } from "@/lib/functions";
-import { TimelineTiming, TimingType } from "@/lib/types";
+import {
+  TimelineTiming,
+  TimingType,
+  TIMELINE_COLORS,
+  TIMELINE_MAX_GREEN,
+  TIMELINE_MAX_RED,
+  TIMELINE_MIN_GREEN,
+  TIMELINE_MIN_RED,
+} from "@/lib/types";
 import { Box, Tooltip } from "@mui/material";
 import { ReactElement } from "react";
 
@@ -8,6 +15,9 @@ type CoreProcessesProps = {
   timings: TimelineTiming[];
   scale: number;
   openRetrievalDialog: (retrievalId: number, type: TimingType) => void;
+  timeMode: boolean;
+  minTiming: number;
+  maxTiming: number;
 };
 
 export function CoreProcesses({
@@ -15,7 +25,24 @@ export function CoreProcesses({
   timings,
   scale,
   openRetrievalDialog,
+  timeMode,
+  minTiming,
+  maxTiming,
 }: CoreProcessesProps): ReactElement {
+  const getColor = (start: number, end: number): string => {
+    const duration = end - start;
+    const percentage = (duration - minTiming) / (maxTiming - minTiming);
+
+    const red =
+      TIMELINE_MIN_RED +
+      Math.floor((TIMELINE_MAX_RED - TIMELINE_MIN_RED) * percentage);
+    const green =
+      TIMELINE_MAX_GREEN -
+      Math.floor((TIMELINE_MAX_GREEN - TIMELINE_MIN_GREEN) * percentage);
+
+    return `rgb(${red}, ${green}, 0)`;
+  };
+
   return (
     <Box
       position="relative"
@@ -46,7 +73,7 @@ export function CoreProcesses({
             border={1}
             borderColor="black"
             borderRadius={2}
-            bgcolor={TIMELINE_COLORS[type]}
+            bgcolor={timeMode ? getColor(start, end) : TIMELINE_COLORS[type]}
             onClick={() => openRetrievalDialog(retrievalId, type)}
           />
         </Tooltip>

--- a/components/timeline/CoreProcesses.tsx
+++ b/components/timeline/CoreProcesses.tsx
@@ -16,8 +16,8 @@ type CoreProcessesProps = {
   scale: number;
   openRetrievalDialog: (retrievalId: number, type: TimingType) => void;
   timeMode: boolean;
-  minTiming: number;
-  maxTiming: number;
+  minDuration: number;
+  maxDuration: number;
   threshold: number;
 };
 
@@ -27,13 +27,13 @@ export function CoreProcesses({
   scale,
   openRetrievalDialog,
   timeMode,
-  minTiming,
-  maxTiming,
+  minDuration,
+  maxDuration,
   threshold,
 }: CoreProcessesProps): ReactElement {
   const getColor = (start: number, end: number): string => {
     const duration = end - start;
-    const percentage = (duration - minTiming) / (maxTiming - minTiming);
+    const percentage = (duration - minDuration) / (maxDuration - minDuration);
 
     const red =
       TIMELINE_MIN_RED +

--- a/components/timeline/CoreProcesses.tsx
+++ b/components/timeline/CoreProcesses.tsx
@@ -18,6 +18,7 @@ type CoreProcessesProps = {
   timeMode: boolean;
   minTiming: number;
   maxTiming: number;
+  threshold: number;
 };
 
 export function CoreProcesses({
@@ -28,6 +29,7 @@ export function CoreProcesses({
   timeMode,
   minTiming,
   maxTiming,
+  threshold,
 }: CoreProcessesProps): ReactElement {
   const getColor = (start: number, end: number): string => {
     const duration = end - start;
@@ -73,7 +75,13 @@ export function CoreProcesses({
             border={1}
             borderColor="black"
             borderRadius={2}
-            bgcolor={timeMode ? getColor(start, end) : TIMELINE_COLORS[type]}
+            bgcolor={
+              end - start < threshold
+                ? "gray"
+                : timeMode
+                  ? getColor(start, end)
+                  : TIMELINE_COLORS[type]
+            }
             onClick={() => openRetrievalDialog(retrievalId, type)}
           />
         </Tooltip>

--- a/components/timeline/TimelineLegend.tsx
+++ b/components/timeline/TimelineLegend.tsx
@@ -5,19 +5,21 @@ import {
   TIMELINE_MIN_GREEN,
   TIMELINE_MIN_RED,
 } from "@/lib/types";
-import { Grid2, Typography } from "@mui/material";
+import { Box, Grid2, Typography } from "@mui/material";
 import { ReactElement } from "react";
 
 type TimelineLegendProps = {
   timeMode: boolean;
   minTiming: number;
   maxTiming: number;
+  threshold: number;
 };
 
 export function TimelineLegend({
   timeMode,
   minTiming,
   maxTiming,
+  threshold,
 }: TimelineLegendProps): ReactElement {
   if (timeMode)
     // Gradient scale from minTiming to maxTiming
@@ -39,7 +41,20 @@ export function TimelineLegend({
           sx={{
             background: `linear-gradient(to right, rgb(${TIMELINE_MIN_RED}, ${TIMELINE_MAX_GREEN}, 0), rgb(${TIMELINE_MAX_RED}, ${TIMELINE_MIN_GREEN}, 0))`,
           }}
-        />
+          position="relative"
+        >
+          {/* Threshold line */}
+          {threshold >= minTiming && threshold <= maxTiming && (
+            <Box
+              position="absolute"
+              left={`${((threshold - minTiming) / (maxTiming - minTiming)) * 200}px`}
+              style={{ transform: "translateX(-50%)" }}
+              width="3px"
+              height="20px"
+              bgcolor="black"
+            />
+          )}
+        </Grid2>
         <Typography>{maxTiming}ms</Typography>
       </Grid2>
     );

--- a/components/timeline/TimelineLegend.tsx
+++ b/components/timeline/TimelineLegend.tsx
@@ -10,19 +10,19 @@ import { ReactElement } from "react";
 
 type TimelineLegendProps = {
   timeMode: boolean;
-  minTiming: number;
-  maxTiming: number;
+  minDuration: number;
+  maxDuration: number;
   threshold: number;
 };
 
 export function TimelineLegend({
   timeMode,
-  minTiming,
-  maxTiming,
+  minDuration,
+  maxDuration,
   threshold,
 }: TimelineLegendProps): ReactElement {
   if (timeMode)
-    // Gradient scale from minTiming to maxTiming
+    // Gradient scale from minDuration to maxDuration
     return (
       <Grid2
         container
@@ -32,7 +32,7 @@ export function TimelineLegend({
         justifyContent="center"
         alignItems="center"
       >
-        <Typography>{minTiming}ms</Typography>
+        <Typography>{minDuration}ms</Typography>
         <Grid2
           width={200}
           height={20}
@@ -44,10 +44,10 @@ export function TimelineLegend({
           position="relative"
         >
           {/* Threshold line */}
-          {threshold >= minTiming && threshold <= maxTiming && (
+          {threshold >= minDuration && threshold <= maxDuration && (
             <Box
               position="absolute"
-              left={`${((threshold - minTiming) / (maxTiming - minTiming)) * 200}px`}
+              left={`${((threshold - minDuration) / (maxDuration - minDuration)) * 200}px`}
               style={{ transform: "translateX(-50%)" }}
               width="3px"
               height="20px"
@@ -55,7 +55,7 @@ export function TimelineLegend({
             />
           )}
         </Grid2>
-        <Typography>{maxTiming}ms</Typography>
+        <Typography>{maxDuration}ms</Typography>
       </Grid2>
     );
 

--- a/components/timeline/TimelineLegend.tsx
+++ b/components/timeline/TimelineLegend.tsx
@@ -1,8 +1,50 @@
-import { TIMELINE_COLORS } from "@/lib/functions";
+import {
+  TIMELINE_COLORS,
+  TIMELINE_MAX_GREEN,
+  TIMELINE_MAX_RED,
+  TIMELINE_MIN_GREEN,
+  TIMELINE_MIN_RED,
+} from "@/lib/types";
 import { Grid2, Typography } from "@mui/material";
 import { ReactElement } from "react";
 
-export function TimelineLegend(): ReactElement {
+type TimelineLegendProps = {
+  timeMode: boolean;
+  minTiming: number;
+  maxTiming: number;
+};
+
+export function TimelineLegend({
+  timeMode,
+  minTiming,
+  maxTiming,
+}: TimelineLegendProps): ReactElement {
+  if (timeMode)
+    // Gradient scale from minTiming to maxTiming
+    return (
+      <Grid2
+        container
+        width="100%"
+        marginTop={2}
+        flexDirection="row"
+        justifyContent="center"
+        alignItems="center"
+      >
+        <Typography>{minTiming}ms</Typography>
+        <Grid2
+          width={200}
+          height={20}
+          borderRadius={4}
+          marginX={1}
+          sx={{
+            background: `linear-gradient(to right, rgb(${TIMELINE_MIN_RED}, ${TIMELINE_MAX_GREEN}, 0), rgb(${TIMELINE_MAX_RED}, ${TIMELINE_MIN_GREEN}, 0))`,
+          }}
+        />
+        <Typography>{maxTiming}ms</Typography>
+      </Grid2>
+    );
+
+  // Legend for each type
   return (
     <Grid2
       container

--- a/lib/functions/buildTimeline.test.ts
+++ b/lib/functions/buildTimeline.test.ts
@@ -69,8 +69,8 @@ describe("buildTimeline", () => {
     const result = buildTimeline([], []);
     expect(result).toEqual({
       nbCores: 0,
-      maxTiming: 0,
-      minTiming: Number.MAX_SAFE_INTEGER,
+      maxDuration: 0,
+      minDuration: Number.MAX_SAFE_INTEGER,
     });
   });
 
@@ -79,8 +79,8 @@ describe("buildTimeline", () => {
 
     const expected: Timeline & {
       nbCores: number;
-      minTiming: number;
-      maxTiming: number;
+      minDuration: number;
+      maxDuration: number;
     } = {
       "0": [
         {
@@ -99,8 +99,8 @@ describe("buildTimeline", () => {
         },
       ],
       nbCores: 2,
-      minTiming: 10,
-      maxTiming: 37,
+      minDuration: 10,
+      maxDuration: 37,
     };
 
     expect(result).toEqual(expected);
@@ -111,8 +111,8 @@ describe("buildTimeline", () => {
 
     const expected: Timeline & {
       nbCores: number;
-      minTiming: number;
-      maxTiming: number;
+      minDuration: number;
+      maxDuration: number;
     } = {
       "0": [
         {
@@ -129,8 +129,8 @@ describe("buildTimeline", () => {
         },
       ],
       nbCores: 1,
-      minTiming: 1,
-      maxTiming: 10,
+      minDuration: 1,
+      maxDuration: 10,
     };
 
     expect(result).toEqual(expected);
@@ -141,8 +141,8 @@ describe("buildTimeline", () => {
 
     const expected: Timeline & {
       nbCores: number;
-      minTiming: number;
-      maxTiming: number;
+      minDuration: number;
+      maxDuration: number;
     } = {
       "0": [
         {
@@ -175,8 +175,8 @@ describe("buildTimeline", () => {
         },
       ],
       nbCores: 3,
-      minTiming: 1,
-      maxTiming: 37,
+      minDuration: 1,
+      maxDuration: 37,
     };
 
     expect(result).toEqual(expected);
@@ -189,8 +189,8 @@ describe("buildTimeline", () => {
 
     const expected: Timeline & {
       nbCores: number;
-      minTiming: number;
-      maxTiming: number;
+      minDuration: number;
+      maxDuration: number;
     } = {
       "0": [
         {
@@ -223,8 +223,8 @@ describe("buildTimeline", () => {
         },
       ],
       nbCores: 3,
-      minTiming: 1,
-      maxTiming: 37,
+      minDuration: 1,
+      maxDuration: 37,
     };
 
     expect(result).toEqual(expected);

--- a/lib/functions/buildTimeline.test.ts
+++ b/lib/functions/buildTimeline.test.ts
@@ -67,13 +67,21 @@ const databaseRetrievals: DatabaseRetrieval[] = [
 describe("buildTimeline", () => {
   it("gives nothing when given nothing", () => {
     const result = buildTimeline([], []);
-    expect(result).toEqual({ nbCores: 0 });
+    expect(result).toEqual({
+      nbCores: 0,
+      maxTiming: 0,
+      minTiming: Number.MAX_SAFE_INTEGER,
+    });
   });
 
   it("builds a timeline from aggregate retrievals", () => {
     const result = buildTimeline(aggregateRetrievals, []);
 
-    const expected: Timeline & { nbCores: number } = {
+    const expected: Timeline & {
+      nbCores: number;
+      minTiming: number;
+      maxTiming: number;
+    } = {
       "0": [
         {
           start: 0,
@@ -91,6 +99,8 @@ describe("buildTimeline", () => {
         },
       ],
       nbCores: 2,
+      minTiming: 10,
+      maxTiming: 37,
     };
 
     expect(result).toEqual(expected);
@@ -99,7 +109,11 @@ describe("buildTimeline", () => {
   it("builds a timeline from database retrievals", () => {
     const result = buildTimeline([], databaseRetrievals);
 
-    const expected: Timeline & { nbCores: number } = {
+    const expected: Timeline & {
+      nbCores: number;
+      minTiming: number;
+      maxTiming: number;
+    } = {
       "0": [
         {
           start: 8,
@@ -115,6 +129,8 @@ describe("buildTimeline", () => {
         },
       ],
       nbCores: 1,
+      minTiming: 1,
+      maxTiming: 10,
     };
 
     expect(result).toEqual(expected);
@@ -123,7 +139,11 @@ describe("buildTimeline", () => {
   it("builds a timeline from both aggregate and database retrievals", () => {
     const result = buildTimeline(aggregateRetrievals, databaseRetrievals);
 
-    const expected: Timeline & { nbCores: number } = {
+    const expected: Timeline & {
+      nbCores: number;
+      minTiming: number;
+      maxTiming: number;
+    } = {
       "0": [
         {
           start: 0,
@@ -155,6 +175,8 @@ describe("buildTimeline", () => {
         },
       ],
       nbCores: 3,
+      minTiming: 1,
+      maxTiming: 37,
     };
 
     expect(result).toEqual(expected);
@@ -165,7 +187,11 @@ describe("buildTimeline", () => {
 
     const result = buildTimeline(aggregateRetrievals, databaseRetrievals);
 
-    const expected: Timeline & { nbCores: number } = {
+    const expected: Timeline & {
+      nbCores: number;
+      minTiming: number;
+      maxTiming: number;
+    } = {
       "0": [
         {
           start: 0,
@@ -197,6 +223,8 @@ describe("buildTimeline", () => {
         },
       ],
       nbCores: 3,
+      minTiming: 1,
+      maxTiming: 37,
     };
 
     expect(result).toEqual(expected);

--- a/lib/functions/buildTimeline.ts
+++ b/lib/functions/buildTimeline.ts
@@ -5,18 +5,13 @@ import {
   TimelineTiming,
 } from "@/lib/types";
 
-export const TIMELINE_COLORS: Record<string, string> = {
-  AggregateRetrieval: "secondary.dark",
-  AggregateRetrievalExecutionContext: "secondary.light",
-  DatabaseRetrieval: "primary.dark",
-  DatabaseRetrievalExecutionContext: "primary.light",
-};
-
 export function buildTimeline(
   aggregateRetrievals: AggregateRetrieval[],
   databaseRetrievals: DatabaseRetrieval[],
-): Timeline & { nbCores: number } {
+): Timeline & { nbCores: number; minTiming: number; maxTiming: number } {
   let maxCores: number = 0;
+  let minTiming: number = Number.MAX_SAFE_INTEGER;
+  let maxTiming: number = 0;
 
   const allTimings: TimelineTiming[] = [];
 
@@ -28,6 +23,19 @@ export function buildTimeline(
       maxCores,
       timingInfo.startTime?.length ?? 0,
       timingInfo.executionContextStartTime?.length ?? 0,
+    );
+    // Keep track of the minimum and maximum timing
+    minTiming = Math.min(
+      minTiming,
+      ...(timingInfo.elapsedTime ?? []).filter((time) => time !== 0),
+      ...(timingInfo.executionContextElapsedTime ?? []).filter(
+        (time) => time !== 0,
+      ),
+    );
+    maxTiming = Math.max(
+      maxTiming,
+      ...(timingInfo.elapsedTime ?? []),
+      ...(timingInfo.executionContextElapsedTime ?? []),
     );
 
     Object.entries(timingInfo).map(([key, values]) => {
@@ -65,6 +73,19 @@ export function buildTimeline(
       maxCores,
       timingInfo.startTime?.length ?? 0,
       timingInfo.executionContextStartTime?.length ?? 0,
+    );
+    // Keep track of the minimum and maximum timing
+    minTiming = Math.min(
+      minTiming,
+      ...(timingInfo.elapsedTime ?? []).filter((time) => time !== 0),
+      ...(timingInfo.executionContextElapsedTime ?? []).filter(
+        (time) => time !== 0,
+      ),
+    );
+    maxTiming = Math.max(
+      maxTiming,
+      ...(timingInfo.elapsedTime ?? []),
+      ...(timingInfo.executionContextElapsedTime ?? []),
     );
 
     Object.entries(timingInfo).map(([key, values]) => {
@@ -127,5 +148,5 @@ export function buildTimeline(
     maxCores = Math.max(maxCores, core + 1);
   }
 
-  return { ...timeline, nbCores: maxCores };
+  return { ...timeline, nbCores: maxCores, minTiming, maxTiming };
 }

--- a/lib/functions/buildTimeline.ts
+++ b/lib/functions/buildTimeline.ts
@@ -8,10 +8,10 @@ import {
 export function buildTimeline(
   aggregateRetrievals: AggregateRetrieval[],
   databaseRetrievals: DatabaseRetrieval[],
-): Timeline & { nbCores: number; minTiming: number; maxTiming: number } {
+): Timeline & { nbCores: number; minDuration: number; maxDuration: number } {
   let maxCores: number = 0;
-  let minTiming: number = Number.MAX_SAFE_INTEGER;
-  let maxTiming: number = 0;
+  let minDuration: number = Number.MAX_SAFE_INTEGER;
+  let maxDuration: number = 0;
 
   const allTimings: TimelineTiming[] = [];
 
@@ -25,15 +25,15 @@ export function buildTimeline(
       timingInfo.executionContextStartTime?.length ?? 0,
     );
     // Keep track of the minimum and maximum timing
-    minTiming = Math.min(
-      minTiming,
+    minDuration = Math.min(
+      minDuration,
       ...(timingInfo.elapsedTime ?? []).filter((time) => time !== 0),
       ...(timingInfo.executionContextElapsedTime ?? []).filter(
         (time) => time !== 0,
       ),
     );
-    maxTiming = Math.max(
-      maxTiming,
+    maxDuration = Math.max(
+      maxDuration,
       ...(timingInfo.elapsedTime ?? []),
       ...(timingInfo.executionContextElapsedTime ?? []),
     );
@@ -75,15 +75,15 @@ export function buildTimeline(
       timingInfo.executionContextStartTime?.length ?? 0,
     );
     // Keep track of the minimum and maximum timing
-    minTiming = Math.min(
-      minTiming,
+    minDuration = Math.min(
+      minDuration,
       ...(timingInfo.elapsedTime ?? []).filter((time) => time !== 0),
       ...(timingInfo.executionContextElapsedTime ?? []).filter(
         (time) => time !== 0,
       ),
     );
-    maxTiming = Math.max(
-      maxTiming,
+    maxDuration = Math.max(
+      maxDuration,
       ...(timingInfo.elapsedTime ?? []),
       ...(timingInfo.executionContextElapsedTime ?? []),
     );
@@ -148,5 +148,5 @@ export function buildTimeline(
     maxCores = Math.max(maxCores, core + 1);
   }
 
-  return { ...timeline, nbCores: maxCores, minTiming, maxTiming };
+  return { ...timeline, nbCores: maxCores, minDuration, maxDuration };
 }

--- a/lib/types/timeline.ts
+++ b/lib/types/timeline.ts
@@ -12,3 +12,15 @@ export type TimelineTiming = {
 };
 
 export type Timeline = Record<number, TimelineTiming[]>;
+
+export const TIMELINE_COLORS: Record<string, string> = {
+  AggregateRetrieval: "secondary.dark",
+  AggregateRetrievalExecutionContext: "secondary.light",
+  DatabaseRetrieval: "primary.dark",
+  DatabaseRetrievalExecutionContext: "primary.light",
+};
+
+export const TIMELINE_MAX_GREEN: number = 175;
+export const TIMELINE_MIN_GREEN: number = 50;
+export const TIMELINE_MAX_RED: number = 255;
+export const TIMELINE_MIN_RED: number = 0;


### PR DESCRIPTION
# Issue Number:

Closes #129 
_The issue will be automatically closed if merged_

# Description:

- Add a time mode displaying process in a green-to-red scale according to their duration
- Add a threshold to "keep" only longer processes and an indicator on the above-mentioned green-to-red scale

# How to test:

- Launch the app `yarn dev`
- Send a query
- Go to timeline page, test the threshold, test the time mode, test both at the same time
