### PR TITLE
fix : retrieval card overflow

### DIFF
--- a/components/RetrievalDialog.tsx
+++ b/components/RetrievalDialog.tsx
@@ -93,7 +93,9 @@ export function RetrievalDialog({
                   Timing Info :
                 </Typography>
 
-                <List>
+                <List
+                  sx={{ overflowX: "auto", display: "block", maxWidth: "100%" }}
+                >
                   {Object.entries(reorderedTimingInfo).map(([key, values]) => (
                     <ListItem key={key} disablePadding>
                       <ListItemText


### PR DESCRIPTION
# Issue Number: #142 

Closes #142 
_The issue will be automatically closed if merged_

# Description:

Value no longer overflow to the side if too many of them

# How to test:

Click on a node on `Nodes` or `Timeline` page from a very large query plan and check that there is a side bar and the display is correct
I suggest `all-countries - contributors query - slow.json` from issue #135 