### PR TITLE
Fix issue #127: Different columns for timings in the slowest nodes table

### DIFF
--- a/app/nodes/page.tsx
+++ b/app/nodes/page.tsx
@@ -9,6 +9,7 @@ import {
   emptyAggregateRetrieval,
   ProcessedNode,
 } from "@/lib/types";
+import InfoIcon from "@mui/icons-material/Info";
 import {
   Box,
   Table,
@@ -25,6 +26,8 @@ import {
   TableSortLabel,
   FormControlLabel,
   Switch,
+  Tooltip,
+  IconButton,
 } from "@mui/material";
 import { ReactElement, useEffect, useState } from "react";
 import { useSelector } from "react-redux";
@@ -34,7 +37,8 @@ export default function NodesPage(): ReactElement {
   const selectedIndex = useSelector(getSelectedIndex);
 
   const [numberOfNodes, setNumberOfNodes] = useState<number>(10);
-  const [sortColumn, setSortColumn] = useState<keyof ProcessedNode>("timing");
+  const [sortColumn, setSortColumn] =
+    useState<keyof ProcessedNode>("totalTiming");
   const [sortOrder, setSortOrder] = useState<"asc" | "desc">("desc");
   const [displayedNodes, setDisplayedNodes] = useState<ProcessedNode[]>([]);
   const [showDialog, setShowDialog] = useState<boolean>(false);
@@ -137,26 +141,59 @@ export default function NodesPage(): ReactElement {
           <TableHead>
             <TableRow>
               {[
-                { id: "id", label: "Node ID" },
-                { id: "timing", label: "Timing (ms)" },
-                { id: "mean", label: "Average (ms)" },
-                { id: "stdDev", label: "Std Dev (ms)" },
-                { id: "parallelCount", label: "Parallel Count" },
+                {
+                  id: "id",
+                  label: "Node ID",
+                  tooltip: "Unique identifier for the node in the query plan",
+                },
+                {
+                  id: "maxTiming",
+                  label: "Max Timing (ms)",
+                  tooltip:
+                    "Maximum execution time among all partitions of this node",
+                },
+                {
+                  id: "totalTiming",
+                  label: "Total Timing (ms)",
+                  tooltip:
+                    "Total elapsed time from the start of the first partition to the end of the last partition",
+                },
+                {
+                  id: "mean",
+                  label: "Average (ms)",
+                  tooltip:
+                    "Mean execution time across all partitions of this node",
+                },
+                {
+                  id: "stdDev",
+                  label: "Std Dev (ms)",
+                  tooltip:
+                    "Standard deviation of execution times across partitions, indicating variability.",
+                },
+                {
+                  id: "parallelCount",
+                  label: "Parallel Count",
+                  tooltip:
+                    "Number of partitions executed in parallel for this node",
+                },
               ].map((column) => (
                 <TableCell
                   key={column.id}
-                  align={
-                    column.id === "id" || column.id === "type"
-                      ? "left"
-                      : "right"
-                  }
+                  align={column.id === "id" ? "left" : "right"}
                 >
                   <TableSortLabel
                     active={sortColumn === column.id}
                     direction={sortOrder}
                     onClick={() => handleSort(column.id as keyof ProcessedNode)}
                   >
-                    {column.label}
+                    <Typography display="flex" alignItems="center">
+                      {column.label}
+                      <Tooltip title={column.tooltip}>
+                        <IconButton size="small">
+                          <InfoIcon fontSize="small" />
+                        </IconButton>
+                      </Tooltip>
+                    </Typography>
                   </TableSortLabel>
                 </TableCell>
               ))}
@@ -176,7 +213,10 @@ export default function NodesPage(): ReactElement {
                 }}
               >
                 <TableCell>{`${node.type} ${node.id}`}</TableCell>
-                <TableCell align="right">{node.timing.toFixed(2)}</TableCell>
+                <TableCell align="right">{node.maxTiming.toFixed(2)}</TableCell>
+                <TableCell align="right">
+                  {node.totalTiming.toFixed(2)}
+                </TableCell>
                 <TableCell align="right">{node.mean.toFixed(2)}</TableCell>
                 <TableCell align="right">{node.stdDev.toFixed(2)}</TableCell>
                 <TableCell align="right">{node.parallelCount}</TableCell>

--- a/lib/functions/slowestNodes.test.ts
+++ b/lib/functions/slowestNodes.test.ts
@@ -79,7 +79,8 @@ describe("getSlowestNodes", () => {
       {
         id: 0,
         type: "Aggregate",
-        timing: 37,
+        maxTiming: 37,
+        totalTiming: 37,
         mean: 37,
         stdDev: 0,
         parallelCount: 1,
@@ -96,7 +97,8 @@ describe("getSlowestNodes", () => {
       {
         id: 1,
         type: "Database",
-        timing: 25,
+        maxTiming: 20,
+        totalTiming: 25,
         mean: 15,
         stdDev: 5,
         parallelCount: 2,
@@ -113,7 +115,8 @@ describe("getSlowestNodes", () => {
       {
         id: 0,
         type: "Aggregate",
-        timing: 37,
+        maxTiming: 37,
+        totalTiming: 37,
         mean: 37,
         stdDev: 0,
         parallelCount: 1,
@@ -121,7 +124,8 @@ describe("getSlowestNodes", () => {
       {
         id: 1,
         type: "Database",
-        timing: 25,
+        maxTiming: 20,
+        totalTiming: 25,
         mean: 15,
         stdDev: 5,
         parallelCount: 2,

--- a/lib/functions/slowestNodes.ts
+++ b/lib/functions/slowestNodes.ts
@@ -13,6 +13,7 @@ function calculateStandardDeviation(values: number[], mean: number): number {
 }
 
 function computeTimingDetails(timingInfo: TimingInfo): {
+  maxTiming: number;
   totalTiming: number;
   meanTiming: number;
   stdDevTiming: number;
@@ -26,6 +27,7 @@ function computeTimingDetails(timingInfo: TimingInfo): {
     startTimes.length != elapsedTimes.length
   ) {
     return {
+      maxTiming: 0,
       totalTiming: 0,
       meanTiming: 0,
       stdDevTiming: 0,
@@ -45,7 +47,10 @@ function computeTimingDetails(timingInfo: TimingInfo): {
     elapsedTimes.reduce((sum, time) => sum + time, 0) / elapsedTimes.length;
   const stdDevTiming = calculateStandardDeviation(elapsedTimes, meanTiming);
 
+  const maxTiming = Math.max(...elapsedTimes);
+
   return {
+    maxTiming,
     totalTiming,
     meanTiming,
     stdDevTiming,
@@ -65,12 +70,18 @@ export function getSlowestNodes(
         node.timingInfo.elapsedTime?.length,
     )
     .map((node) => {
-      const { totalTiming, meanTiming, stdDevTiming, parallelCount } =
-        computeTimingDetails(node.timingInfo);
+      const {
+        maxTiming,
+        totalTiming,
+        meanTiming,
+        stdDevTiming,
+        parallelCount,
+      } = computeTimingDetails(node.timingInfo);
       return {
         id: node.retrievalId,
         type: "Aggregate",
-        timing: totalTiming,
+        maxTiming,
+        totalTiming,
         mean: meanTiming,
         stdDev: stdDevTiming,
         parallelCount,
@@ -84,12 +95,18 @@ export function getSlowestNodes(
         node.timingInfo.elapsedTime?.length,
     )
     .map((node) => {
-      const { totalTiming, meanTiming, stdDevTiming, parallelCount } =
-        computeTimingDetails(node.timingInfo);
+      const {
+        maxTiming,
+        totalTiming,
+        meanTiming,
+        stdDevTiming,
+        parallelCount,
+      } = computeTimingDetails(node.timingInfo);
       return {
         id: node.retrievalId,
         type: "Database",
-        timing: totalTiming,
+        maxTiming,
+        totalTiming,
         mean: meanTiming,
         stdDev: stdDevTiming,
         parallelCount,
@@ -98,5 +115,7 @@ export function getSlowestNodes(
 
   const allNodes: ProcessedNode[] = [...aggregateNodes, ...databaseNodes];
 
-  return allNodes.sort((a, b) => b.timing - a.timing).slice(0, numberOfNodes);
+  return allNodes
+    .sort((a, b) => b.totalTiming - a.totalTiming)
+    .slice(0, numberOfNodes);
 }

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -4,7 +4,8 @@ export * from "./timeline";
 export type ProcessedNode = {
   id: number;
   type: "Aggregate" | "Database";
-  timing: number;
+  maxTiming: number;
+  totalTiming: number;
   parallelCount: number;
   mean: number;
   stdDev: number;


### PR DESCRIPTION
# Issue Number: 127

Closes #127 

# Description:

Add a new column in the SlowestNodes table : Max Timing 
Rename the previous "Timing" column by Total Timing
Add tooltips in the head of the table so that it easier to understand

# How to test:

Launch the app `yarn dev`
Add your query plan
Go to the "Nodes" page
Look at the new column, and the tooltips

