### PR TITLE
fix : removing fixed color

### DIFF
--- a/app/summary/page.tsx
+++ b/app/summary/page.tsx
@@ -95,13 +95,7 @@ export default function SummaryPage(): ReactElement {
       {/* Aggregation option, only if several pass*/}
       {queryPlan.length >= 2 && (
         <Grid2 container spacing={2}>
-          <Card
-            style={{
-              backgroundColor: isDataAggregated
-                ? "rgb(40, 40, 40)"
-                : "rgb(20, 20, 20)",
-            }}
-          >
+          <Card>
             <CardContent>
               <Typography display="flex" alignItems="center">
                 Aggregate all parts


### PR DESCRIPTION
# Issue Number: #153 

Closes #153 
_The issue will be automatically closed if merged_

# Description:

A card in sumamry page has a fixed color; we remove it
In all cases this card will probably be removed completely if aggregate is placed in the header

# How to test:

Summary page: check that the card for aggregation is readable in light mode
