### PR TITLE
Fixing issue #126: add a new page to determine the longest passes

### DIFF
--- a/app/passes/layout.tsx
+++ b/app/passes/layout.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from "next";
+import type { ReactElement } from "react";
+
+export const metadata: Metadata = {
+  title: "Longest passes",
+};
+
+export default function QueryLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>): ReactElement {
+  return <>{children}</>;
+}

--- a/app/passes/page.tsx
+++ b/app/passes/page.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { getPassesTimings } from "@/lib/functions";
+import { getQueryPlan } from "@/lib/redux";
+import {
+  Box,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from "@mui/material";
+import { ReactElement } from "react";
+import { useSelector } from "react-redux";
+
+export default function PassesPage(): ReactElement {
+  const queryPlan = useSelector(getQueryPlan);
+
+  if (!queryPlan || queryPlan.length === 0) {
+    return (
+      <Typography>
+        The query plan is empty. Please run a query to see the passes.
+      </Typography>
+    );
+  }
+
+  const passesTimings = getPassesTimings(queryPlan);
+
+  return (
+    <Box padding={2} width="100%">
+      <Typography variant="h4" gutterBottom>
+        Passes Timings
+      </Typography>
+
+      <TableContainer component={Paper}>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell>Pass Name</TableCell>
+              <TableCell align="right">Total Timing (ms)</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {passesTimings.map((row, index) => (
+              <TableRow key={index}>
+                <TableCell>{row.passName}</TableCell>
+                <TableCell align="right">{row.totalTiming}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </Box>
+  );
+}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -29,6 +29,9 @@ export function Header(): ReactElement {
               <Link href="/nodes">
                 <Button variant="outlined">Nodes</Button>
               </Link>
+              <Link href="/passes">
+                <Button variant="outlined">Passes</Button>
+              </Link>
             </>
           )}
           <div className="py-3 ml-auto">

--- a/components/PlanSelector.tsx
+++ b/components/PlanSelector.tsx
@@ -17,8 +17,9 @@ export default function PlanSelector(): ReactElement {
   const dispatch = useAppDispatch();
 
   const pathname = usePathname();
+  const excludedPaths = ["/submit-query", "/passes"];
 
-  if (pathname == "/submit-query" || !queryPlan || queryPlan.length < 2)
+  if (excludedPaths.includes(pathname) || !queryPlan || queryPlan.length < 2)
     return <></>;
 
   return (

--- a/lib/functions/index.ts
+++ b/lib/functions/index.ts
@@ -1,5 +1,6 @@
 export * from "./aggregation";
 export * from "./buildTimeline";
+export * from "./passesTimings";
 export * from "./postRequest";
 export * from "./slowestNodes";
 export * from "./summary";

--- a/lib/functions/passesTimings.test.ts
+++ b/lib/functions/passesTimings.test.ts
@@ -1,0 +1,112 @@
+import {
+  AggregateRetrieval,
+  DatabaseRetrieval,
+  emptyAggregateRetrieval,
+  emptyDatabaseRetrieval,
+  emptyPlanInfo,
+  emptyQueryPlan,
+  QueryPlan,
+} from "@/lib/types";
+import { getPassesTimings, PassTiming } from "./passesTimings";
+
+const firstAggregateRetrievals: AggregateRetrieval[] = [
+  {
+    ...emptyAggregateRetrieval,
+    timingInfo: {
+      startTime: [0, 20],
+      elapsedTime: [37, 12],
+      executionContextStartTime: [0, 5],
+      executionContextElapsedTime: [10, 5],
+    },
+  },
+];
+
+const firstPass: QueryPlan = {
+  ...emptyQueryPlan,
+  planInfo: {
+    ...emptyPlanInfo,
+    mdxPass: "First pass",
+  },
+  aggregateRetrievals: firstAggregateRetrievals,
+};
+
+const secondAggregateRetrievals: AggregateRetrieval[] = [
+  {
+    ...emptyAggregateRetrieval,
+    timingInfo: {
+      startTime: [0, 20, 12],
+      elapsedTime: [4, 13, 12],
+      executionContextStartTime: [0, 10],
+      executionContextElapsedTime: [5, 5],
+    },
+  },
+];
+
+const secondDatabaseRetrievals: DatabaseRetrieval[] = [
+  {
+    ...emptyDatabaseRetrieval,
+    timingInfo: {
+      startTime: [10, 12, 12],
+      elapsedTime: [2, 4, 5],
+      executionContextStartTime: [0, 0],
+      executionContextElapsedTime: [0, 0],
+    },
+  },
+  {
+    ...emptyDatabaseRetrieval,
+    timingInfo: {
+      startTime: [50, 40],
+      elapsedTime: [10, 10],
+      executionContextStartTime: [20, 35],
+      executionContextElapsedTime: [10, 10],
+    },
+  },
+];
+
+const secondPass: QueryPlan = {
+  ...emptyQueryPlan,
+  planInfo: {
+    ...emptyPlanInfo,
+    mdxPass: "Second pass",
+  },
+  aggregateRetrievals: secondAggregateRetrievals,
+  databaseRetrievals: secondDatabaseRetrievals,
+};
+
+describe("passesTimings", () => {
+  it("gives nothing when given nothing", () => {
+    const result = getPassesTimings([]);
+
+    expect(result).toEqual([]);
+  });
+
+  it("gives the timing of the pass when given one", () => {
+    const result = getPassesTimings([firstPass]);
+
+    const expected: PassTiming[] = [
+      {
+        passName: "First pass",
+        totalTiming: 37,
+      },
+    ];
+
+    expect(result).toEqual(expected);
+  });
+
+  it("gives two timing when given two passes", () => {
+    const result = getPassesTimings([firstPass, secondPass]);
+
+    const expected: PassTiming[] = [
+      {
+        passName: "First pass",
+        totalTiming: 37,
+      },
+      {
+        passName: "Second pass",
+        totalTiming: 60,
+      },
+    ];
+
+    expect(result).toEqual(expected);
+  });
+});

--- a/lib/functions/passesTimings.ts
+++ b/lib/functions/passesTimings.ts
@@ -1,0 +1,41 @@
+import { AggregateRetrieval, DatabaseRetrieval, QueryPlan } from "@/lib/types";
+
+export type PassTiming = {
+  passName: string;
+  totalTiming: number;
+};
+
+function getMaxRetrievalTimings(
+  retrieval: AggregateRetrieval | DatabaseRetrieval,
+): number {
+  const elapsedTimes: number[] = retrieval.timingInfo.elapsedTime ?? [];
+  const endTimes: number[] = (retrieval.timingInfo.startTime ?? []).map(
+    (num, idx) => num + elapsedTimes[idx],
+  );
+  const executionContextElapsedTimes: number[] =
+    retrieval.timingInfo.executionContextElapsedTime ?? [];
+  const executionContextEndTimes: number[] = (
+    retrieval.timingInfo.executionContextStartTime ?? []
+  ).map((num, idx) => num + executionContextElapsedTimes[idx]);
+
+  return endTimes
+    .concat(executionContextEndTimes)
+    .reduce((a, b) => Math.max(a, b), 0);
+}
+
+function passTiming(pass: QueryPlan): PassTiming {
+  const maxRetrievalTimings = pass.aggregateRetrievals
+    .map(getMaxRetrievalTimings)
+    .concat(pass.databaseRetrievals.map(getMaxRetrievalTimings));
+
+  console.log(pass.planInfo.mdxPass, maxRetrievalTimings);
+
+  return {
+    passName: pass.planInfo.mdxPass,
+    totalTiming: Math.max(...maxRetrievalTimings, 0),
+  };
+}
+
+export function getPassesTimings(queryPlan: QueryPlan[]): PassTiming[] {
+  return queryPlan.map(passTiming);
+}

--- a/lib/functions/passesTimings.ts
+++ b/lib/functions/passesTimings.ts
@@ -28,8 +28,6 @@ function passTiming(pass: QueryPlan): PassTiming {
     .map(getMaxRetrievalTimings)
     .concat(pass.databaseRetrievals.map(getMaxRetrievalTimings));
 
-  console.log(pass.planInfo.mdxPass, maxRetrievalTimings);
-
   return {
     passName: pass.planInfo.mdxPass,
     totalTiming: Math.max(...maxRetrievalTimings, 0),

--- a/lib/types/queryPlan.ts
+++ b/lib/types/queryPlan.ts
@@ -23,6 +23,10 @@ const planInfoSchema = z.object({
   continuous: z.boolean().default(false),
 });
 
+export type PlanInfo = z.infer<typeof planInfoSchema>;
+
+export const emptyPlanInfo: PlanInfo = planInfoSchema.parse({});
+
 const locationSchema = z.object({
   dimension: z.string().default(""),
   hierarchy: z.string().default(""),
@@ -72,6 +76,8 @@ export type DatabaseRetrieval = z.infer<typeof databaseRetrievalSchema>;
 export type AggregatedDatabaseRetrieval = DatabaseRetrieval & {
   pass: string;
 };
+export const emptyDatabaseRetrieval: DatabaseRetrieval =
+  databaseRetrievalSchema.parse({});
 
 const dependenciesSchema = z
   .record(z.string(), z.array(z.number()))


### PR DESCRIPTION
# Issue Number: 126

Closes #126 
_The issue will be automatically closed if merged_

# Description:

Add a new page to determine the longest passes
Please note: very simple page for the moment, only a basic table, destined to evolve in the future

The PlanSelector is desactivated in the header in this page
Unit tests are performed for the function used

# How to test:

Launch the app `yarn dev`
Load a query plan (with several passes)
Go to page: "Passes"

