### PR TITLE
fix : align only mode for card display

### DIFF
--- a/components/RetrievalDialog.tsx
+++ b/components/RetrievalDialog.tsx
@@ -12,8 +12,6 @@ import {
   ListItem,
   ListItemText,
   Divider,
-  Switch,
-  Tooltip,
 } from "@mui/material";
 import { type ReactElement } from "react";
 

--- a/components/RetrievalDialog.tsx
+++ b/components/RetrievalDialog.tsx
@@ -30,7 +30,6 @@ export function RetrievalDialog({
   open,
   setOpen,
 }: RetrievalDialogProps): ReactElement | null {
-  const [areNumbersAligned, setAreNumbersAligned] = useState<boolean>(false);
   if (!retrieval) return null;
 
   const isAggregate = "partialProviderName" in retrieval;
@@ -113,12 +112,9 @@ export function RetrievalDialog({
                             {values
                               .map((value) => {
                                 const strValue = String(value);
-                                if (areNumbersAligned) {
-                                  const diff =
-                                    maxDurationInfoLength - strValue.length;
-                                  return " ".repeat(diff) + strValue;
-                                }
-                                return strValue;
+                                const diff =
+                                  maxDurationInfoLength - strValue.length;
+                                return " ".repeat(diff) + strValue;
                               })
                               .join(", ")}
                           </Typography>
@@ -127,13 +123,6 @@ export function RetrievalDialog({
                     </ListItem>
                   ))}
                 </List>
-                <Tooltip title="Align numbers" arrow placement="right">
-                  <Switch
-                    checked={areNumbersAligned}
-                    onChange={() => setAreNumbersAligned((prev) => !prev)}
-                    sx={{ transform: "scale(0.8)" }}
-                  />
-                </Tooltip>
               </>
             )}
             <Divider sx={{ marginTop: 1, marginBottom: 3 }} />

--- a/components/RetrievalDialog.tsx
+++ b/components/RetrievalDialog.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { AggregateRetrieval, DatabaseRetrieval } from "@/lib/types";
 import { Close } from "@mui/icons-material";
 import {
@@ -17,7 +15,7 @@ import {
   Switch,
   Tooltip,
 } from "@mui/material";
-import { type ReactElement, useState } from "react";
+import { type ReactElement } from "react";
 
 type RetrievalDialogProps = {
   retrieval: AggregateRetrieval | DatabaseRetrieval;


### PR DESCRIPTION
# Issue Number: #151 

Closes #151 
_The issue will be automatically closed if merged_

# Description:

Numbers of `timingInfo` are now only aligned, no more option, as requested

# How to test:

Launch the app
Load a query plan with some timings
Check on `nodes` or `timeline` page by clicking on a node that the display of `timingInfo` numbers is aligned.

# Notes:

`use client;` was added to that component to use useState but was not there from the beginning, so I deleted it again
