### PR TITLE
Adding information for users on summary page

### DIFF
--- a/app/summary/page.tsx
+++ b/app/summary/page.tsx
@@ -127,9 +127,16 @@ export default function SummaryPage(): ReactElement {
             {/* Line 1*/}
             <Grid2 container padding={1} spacing={2} justifyContent="center">
               <Grid2 padding={1} spacing={1} direction="column">
-                <Typography variant="h6">
-                  Elapsed timings of retrievals
-                </Typography>
+                <Box display="flex" alignItems="center" gap={1}>
+                  <Typography variant="h6">
+                    Elapsed timings of retrievals
+                  </Typography>
+                  <Tooltip title="How long do the retrievals take, by type">
+                    <IconButton size="small" style={{ marginLeft: 8 }}>
+                      <InfoIcon fontSize="small" />
+                    </IconButton>
+                  </Tooltip>
+                </Box>
                 <Box
                   sx={{
                     border: "1px solid #ccc",
@@ -373,7 +380,14 @@ export default function SummaryPage(): ReactElement {
                 </Box>
               </Grid2>
               <Grid2 padding={1} spacing={1}>
-                <Typography variant="h6">Global timings</Typography>
+                <Box display="flex" alignItems="center" gap={1}>
+                  <Typography variant="h6">Global timings</Typography>
+                  <Tooltip title="Total timings of all the query plan">
+                    <IconButton size="small" style={{ marginLeft: 8 }}>
+                      <InfoIcon fontSize="small" />
+                    </IconButton>
+                  </Tooltip>
+                </Box>
                 {selectedQueryPlan.planInfo?.globalTimings ? (
                   <Box
                     sx={{
@@ -402,7 +416,14 @@ export default function SummaryPage(): ReactElement {
             {/* Line 2*/}
             <Grid2 container padding={1} spacing={2} justifyContent="center">
               <Grid2 padding={1} spacing={1} direction="column">
-                <Typography variant="h6">Number of retrievals</Typography>
+                <Box display="flex" alignItems="center" gap={1}>
+                  <Typography variant="h6">Number of retrievals</Typography>
+                  <Tooltip title="Number of retrievals, by type">
+                    <IconButton size="small" style={{ marginLeft: 8 }}>
+                      <InfoIcon fontSize="small" />
+                    </IconButton>
+                  </Tooltip>
+                </Box>
 
                 <Box
                   sx={{
@@ -523,7 +544,14 @@ export default function SummaryPage(): ReactElement {
                 </Box>
               </Grid2>
               <Grid2 padding={1} spacing={1} direction="column">
-                <Typography variant="h6">Measures</Typography>
+                <Box display="flex" alignItems="center" gap={1}>
+                  <Typography variant="h6">Measures</Typography>
+                  <Tooltip title="The different measures that are queried">
+                    <IconButton size="small" style={{ marginLeft: 8 }}>
+                      <InfoIcon fontSize="small" />
+                    </IconButton>
+                  </Tooltip>
+                </Box>
                 <Box
                   sx={{
                     border: "1px solid #ccc",


### PR DESCRIPTION
# Issue Number: #131 

Closes #131 
_The issue will be automatically closed if merged_

# Description:

Adding tooltips for the user on summary page

# How to test:

Launch app `yarn dev`
Go to summary page
Check that the tooltips are there and worl