### PR TITLE
Fixing issue #152: add colors in the slowest nodes page

### DIFF
--- a/app/nodes/page.tsx
+++ b/app/nodes/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { NodesTable, RetrievalDialog } from "@/components";
+import { NodesLegend } from "@/components/nodes/NodesLegend";
 import { aggregateData, getSlowestNodes } from "@/lib/functions";
 import { getQueryPlan, getSelectedIndex } from "@/lib/redux";
 import {
@@ -25,6 +26,8 @@ export default function NodesPage(): ReactElement {
   const [sortColumn, setSortColumn] =
     useState<keyof ProcessedNode>("totalTiming");
   const [sortOrder, setSortOrder] = useState<"asc" | "desc">("desc");
+  const [minDuration, setMinDuration] = useState<number>(0);
+  const [maxDuration, setMaxDuration] = useState<number>(0);
   const [displayedNodes, setDisplayedNodes] = useState<ProcessedNode[]>([]);
   const [showDialog, setShowDialog] = useState<boolean>(false);
   const [selectedRetrieval, setSelectedRetrieval] = useState<
@@ -36,8 +39,13 @@ export default function NodesPage(): ReactElement {
       let selectedQueryPlan: QueryPlan | AggregatedQueryPlan;
       if (selectedIndex === -1) selectedQueryPlan = aggregateData(queryPlan);
       else selectedQueryPlan = queryPlan[selectedIndex];
-      const nodes = getSlowestNodes(selectedQueryPlan, numberOfNodes);
-      setDisplayedNodes(nodes);
+      const { minDuration, maxDuration, processedNodes } = getSlowestNodes(
+        selectedQueryPlan,
+        numberOfNodes,
+      );
+      setMinDuration(minDuration);
+      setMaxDuration(maxDuration);
+      setDisplayedNodes(processedNodes);
     }
   }, [queryPlan, selectedIndex, numberOfNodes]);
 
@@ -112,10 +120,14 @@ export default function NodesPage(): ReactElement {
         />
       </Grid2>
 
+      <NodesLegend minDuration={minDuration} maxDuration={maxDuration} />
+
       <NodesTable
         displayedNodes={displayedNodes}
         sortColumn={sortColumn}
         sortOrder={sortOrder}
+        minDuration={minDuration}
+        maxDuration={maxDuration}
         handleSort={handleSort}
         getRetrievalFromNode={getRetrievalFromNode}
         setSelectedRetrieval={setSelectedRetrieval}

--- a/app/nodes/page.tsx
+++ b/app/nodes/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { RetrievalDialog } from "@/components";
+import { NodesTable, RetrievalDialog } from "@/components";
 import { aggregateData, getSlowestNodes } from "@/lib/functions";
 import { getQueryPlan, getSelectedIndex } from "@/lib/redux";
 import {
@@ -13,24 +13,7 @@ import {
   ProcessedNode,
   QueryPlan,
 } from "@/lib/types";
-import InfoIcon from "@mui/icons-material/Info";
-import {
-  Box,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Typography,
-  Paper,
-  InputLabel,
-  Grid2,
-  Slider,
-  TableSortLabel,
-  Tooltip,
-  IconButton,
-} from "@mui/material";
+import { Box, Typography, InputLabel, Grid2, Slider } from "@mui/material";
 import { ReactElement, useEffect, useState } from "react";
 import { useSelector } from "react-redux";
 
@@ -129,98 +112,16 @@ export default function NodesPage(): ReactElement {
         />
       </Grid2>
 
-      <TableContainer component={Paper}>
-        <Table>
-          <TableHead>
-            <TableRow>
-              {[
-                {
-                  id: "id",
-                  label: "Node ID",
-                  tooltip: "Unique identifier for the node in the query plan",
-                },
-                {
-                  id: "maxTiming",
-                  label: "Max Timing (ms)",
-                  tooltip:
-                    "Maximum execution time among all partitions of this node",
-                },
-                {
-                  id: "totalTiming",
-                  label: "Total Timing (ms)",
-                  tooltip:
-                    "Total elapsed time from the start of the first partition to the end of the last partition",
-                },
-                {
-                  id: "mean",
-                  label: "Average (ms)",
-                  tooltip:
-                    "Mean execution time across all partitions of this node",
-                },
-                {
-                  id: "stdDev",
-                  label: "Std Dev (ms)",
-                  tooltip:
-                    "Standard deviation of execution times across partitions, indicating variability.",
-                },
-                {
-                  id: "parallelCount",
-                  label: "Parallel Count",
-                  tooltip:
-                    "Number of partitions executed in parallel for this node",
-                },
-              ].map((column) => (
-                <TableCell
-                  key={column.id}
-                  align={column.id === "id" ? "left" : "right"}
-                >
-                  <TableSortLabel
-                    active={sortColumn === column.id}
-                    direction={sortOrder}
-                    onClick={() => handleSort(column.id as keyof ProcessedNode)}
-                  >
-                    <Typography display="flex" alignItems="center">
-                      {column.label}
-                      <Tooltip title={column.tooltip}>
-                        <IconButton size="small">
-                          <InfoIcon fontSize="small" />
-                        </IconButton>
-                      </Tooltip>
-                    </Typography>
-                  </TableSortLabel>
-                </TableCell>
-              ))}
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {displayedNodes.map((node) => (
-              <TableRow
-                key={`${node.pass} ${node.type} ${node.id}`}
-                onClick={() => {
-                  setSelectedRetrieval(getRetrievalFromNode(node));
-                  setShowDialog(true);
-                }}
-                sx={{
-                  cursor: "pointer",
-                  "&:hover": { bgcolor: "rgba(0, 0, 0, 0.04)" },
-                }}
-              >
-                <TableCell>
-                  {selectedIndex === -1 && `${node.pass} `}
-                  {node.type} {node.id}
-                </TableCell>
-                <TableCell align="right">{node.maxTiming.toFixed(2)}</TableCell>
-                <TableCell align="right">
-                  {node.totalTiming.toFixed(2)}
-                </TableCell>
-                <TableCell align="right">{node.mean.toFixed(2)}</TableCell>
-                <TableCell align="right">{node.stdDev.toFixed(2)}</TableCell>
-                <TableCell align="right">{node.parallelCount}</TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </TableContainer>
+      <NodesTable
+        displayedNodes={displayedNodes}
+        sortColumn={sortColumn}
+        sortOrder={sortOrder}
+        handleSort={handleSort}
+        getRetrievalFromNode={getRetrievalFromNode}
+        setSelectedRetrieval={setSelectedRetrieval}
+        setShowDialog={setShowDialog}
+        selectedIndex={selectedIndex}
+      />
 
       <RetrievalDialog
         retrieval={selectedRetrieval}

--- a/app/passes/page.tsx
+++ b/app/passes/page.tsx
@@ -2,6 +2,7 @@
 
 import { getPassesTimings } from "@/lib/functions";
 import { getQueryPlan } from "@/lib/redux";
+import InfoIcon from "@mui/icons-material/Info";
 import {
   Box,
   Paper,
@@ -15,7 +16,6 @@ import {
   Tooltip,
   IconButton,
 } from "@mui/material";
-import InfoIcon from "@mui/icons-material/Info";
 import { ReactElement } from "react";
 import { useSelector } from "react-redux";
 

--- a/components/index.ts
+++ b/components/index.ts
@@ -1,6 +1,7 @@
 export * from "./FileExporter";
 export * from "./FileUploader";
 export * from "./Header";
+export * from "./nodes";
 export * from "./PlanSelector";
 export * from "./Providers";
 export * from "./RetrievalDialog";

--- a/components/nodes/NodesLegend.tsx
+++ b/components/nodes/NodesLegend.tsx
@@ -1,0 +1,43 @@
+import {
+  NODES_MAX_GREEN,
+  NODES_MAX_RED,
+  NODES_MIN_GREEN,
+  NODES_MIN_RED,
+} from "@/lib/types";
+import { Grid2, Typography } from "@mui/material";
+import { ReactElement } from "react";
+
+type NodesLegendProps = {
+  minDuration: number;
+  maxDuration: number;
+};
+
+export function NodesLegend({
+  minDuration,
+  maxDuration,
+}: NodesLegendProps): ReactElement {
+  // Gradient scale from minDuration to maxDuration
+  return (
+    <Grid2
+      container
+      width="100%"
+      marginY={2}
+      flexDirection="row"
+      justifyContent="center"
+      alignItems="center"
+    >
+      <Typography>{minDuration}ms</Typography>
+      <Grid2
+        width={200}
+        height={20}
+        borderRadius={4}
+        marginX={1}
+        sx={{
+          background: `linear-gradient(to right, rgba(${NODES_MIN_RED}, ${NODES_MAX_GREEN}, 0.8), rgba(${NODES_MAX_RED}, ${NODES_MIN_GREEN}, 0.8))`,
+        }}
+        position="relative"
+      ></Grid2>
+      <Typography>{maxDuration}ms</Typography>
+    </Grid2>
+  );
+}

--- a/components/nodes/NodesLegend.tsx
+++ b/components/nodes/NodesLegend.tsx
@@ -1,9 +1,4 @@
-import {
-  NODES_MAX_GREEN,
-  NODES_MAX_RED,
-  NODES_MIN_GREEN,
-  NODES_MIN_RED,
-} from "@/lib/types";
+import { MAX_GREEN, MAX_RED, MIN_GREEN, MIN_RED } from "@/lib/types";
 import { Grid2, Typography } from "@mui/material";
 import { ReactElement } from "react";
 
@@ -33,7 +28,7 @@ export function NodesLegend({
         borderRadius={4}
         marginX={1}
         sx={{
-          background: `linear-gradient(to right, rgba(${NODES_MIN_RED}, ${NODES_MAX_GREEN}, 0.8), rgba(${NODES_MAX_RED}, ${NODES_MIN_GREEN}, 0.8))`,
+          background: `linear-gradient(to right, rgba(${MIN_RED}, ${MAX_GREEN}, 0.8), rgba(${MAX_RED}, ${MIN_GREEN}, 0.8))`,
         }}
         position="relative"
       ></Grid2>

--- a/components/nodes/NodesTable.tsx
+++ b/components/nodes/NodesTable.tsx
@@ -1,0 +1,139 @@
+import {
+  ProcessedNode,
+  AggregateRetrieval,
+  DatabaseRetrieval,
+} from "@/lib/types";
+import InfoIcon from "@mui/icons-material/Info";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TableSortLabel,
+  Tooltip,
+  IconButton,
+  Paper,
+  Typography,
+} from "@mui/material";
+import { ReactElement } from "react";
+
+interface NodesTableProps {
+  displayedNodes: ProcessedNode[];
+  sortColumn: keyof ProcessedNode;
+  sortOrder: "asc" | "desc";
+  handleSort: (column: keyof ProcessedNode) => void;
+  getRetrievalFromNode: (
+    node: ProcessedNode,
+  ) => AggregateRetrieval | DatabaseRetrieval;
+  setSelectedRetrieval: (
+    retrieval: AggregateRetrieval | DatabaseRetrieval,
+  ) => void;
+  setShowDialog: (open: boolean) => void;
+  selectedIndex: number;
+}
+
+export function NodesTable({
+  displayedNodes,
+  sortColumn,
+  sortOrder,
+  handleSort,
+  getRetrievalFromNode,
+  setSelectedRetrieval,
+  setShowDialog,
+  selectedIndex,
+}: NodesTableProps): ReactElement {
+  return (
+    <TableContainer component={Paper}>
+      <Table>
+        <TableHead>
+          <TableRow>
+            {[
+              {
+                id: "id",
+                label: "Node ID",
+                tooltip: "Unique identifier for the node in the query plan",
+              },
+              {
+                id: "maxTiming",
+                label: "Max Timing (ms)",
+                tooltip:
+                  "Maximum execution time among all partitions of this node",
+              },
+              {
+                id: "totalTiming",
+                label: "Total Timing (ms)",
+                tooltip:
+                  "Total elapsed time from the start of the first partition to the end of the last partition",
+              },
+              {
+                id: "mean",
+                label: "Average (ms)",
+                tooltip:
+                  "Mean execution time across all partitions of this node",
+              },
+              {
+                id: "stdDev",
+                label: "Std Dev (ms)",
+                tooltip:
+                  "Standard deviation of execution times across partitions, indicating variability.",
+              },
+              {
+                id: "parallelCount",
+                label: "Parallel Count",
+                tooltip:
+                  "Number of partitions executed in parallel for this node",
+              },
+            ].map((column) => (
+              <TableCell
+                key={column.id}
+                align={column.id === "id" ? "left" : "right"}
+              >
+                <TableSortLabel
+                  active={sortColumn === column.id}
+                  direction={sortOrder}
+                  onClick={() => handleSort(column.id as keyof ProcessedNode)}
+                >
+                  <Typography display="flex" alignItems="center">
+                    {column.label}
+                    <Tooltip title={column.tooltip}>
+                      <IconButton size="small">
+                        <InfoIcon fontSize="small" />
+                      </IconButton>
+                    </Tooltip>
+                  </Typography>
+                </TableSortLabel>
+              </TableCell>
+            ))}
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {displayedNodes.map((node) => (
+            <TableRow
+              key={`${node.pass} ${node.type} ${node.id}`}
+              onClick={() => {
+                setSelectedRetrieval(getRetrievalFromNode(node));
+                setShowDialog(true);
+              }}
+              sx={{
+                cursor: "pointer",
+                "&:hover": { bgcolor: "rgba(0, 0, 0, 0.04)" },
+              }}
+            >
+              <TableCell>
+                {selectedIndex === -1 && `${node.pass} `}
+                {node.type} {node.id}
+              </TableCell>
+              <TableCell align="right">{node.maxTiming.toFixed(2)}</TableCell>
+              <TableCell align="right">{node.totalTiming.toFixed(2)}</TableCell>
+              <TableCell align="right">{node.mean.toFixed(2)}</TableCell>
+              <TableCell align="right">{node.stdDev.toFixed(2)}</TableCell>
+              <TableCell align="right">{node.parallelCount}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}

--- a/components/nodes/NodesTable.tsx
+++ b/components/nodes/NodesTable.tsx
@@ -2,10 +2,10 @@ import {
   ProcessedNode,
   AggregateRetrieval,
   DatabaseRetrieval,
-  NODES_MIN_RED,
-  NODES_MAX_RED,
-  NODES_MAX_GREEN,
-  NODES_MIN_GREEN,
+  MIN_RED,
+  MAX_RED,
+  MAX_GREEN,
+  MIN_GREEN,
 } from "@/lib/types";
 import InfoIcon from "@mui/icons-material/Info";
 import {
@@ -55,11 +55,8 @@ export function NodesTable({
   const getColor = (duration: number, hover?: boolean): string => {
     const percentage = (duration - minDuration) / (maxDuration - minDuration);
 
-    const red =
-      NODES_MIN_RED + Math.floor((NODES_MAX_RED - NODES_MIN_RED) * percentage);
-    const green =
-      NODES_MAX_GREEN -
-      Math.floor((NODES_MAX_GREEN - NODES_MIN_GREEN) * percentage);
+    const red = MIN_RED + Math.floor((MAX_RED - MIN_RED) * percentage);
+    const green = MAX_GREEN - Math.floor((MAX_GREEN - MIN_GREEN) * percentage);
 
     return `rgba(${red}, ${green}, 0, ${hover ? 0.5 : 0.8})`;
   };

--- a/components/nodes/NodesTable.tsx
+++ b/components/nodes/NodesTable.tsx
@@ -2,6 +2,10 @@ import {
   ProcessedNode,
   AggregateRetrieval,
   DatabaseRetrieval,
+  NODES_MIN_RED,
+  NODES_MAX_RED,
+  NODES_MAX_GREEN,
+  NODES_MIN_GREEN,
 } from "@/lib/types";
 import InfoIcon from "@mui/icons-material/Info";
 import {
@@ -23,6 +27,8 @@ interface NodesTableProps {
   displayedNodes: ProcessedNode[];
   sortColumn: keyof ProcessedNode;
   sortOrder: "asc" | "desc";
+  minDuration: number;
+  maxDuration: number;
   handleSort: (column: keyof ProcessedNode) => void;
   getRetrievalFromNode: (
     node: ProcessedNode,
@@ -38,12 +44,26 @@ export function NodesTable({
   displayedNodes,
   sortColumn,
   sortOrder,
+  minDuration,
+  maxDuration,
   handleSort,
   getRetrievalFromNode,
   setSelectedRetrieval,
   setShowDialog,
   selectedIndex,
 }: NodesTableProps): ReactElement {
+  const getColor = (duration: number, hover?: boolean): string => {
+    const percentage = (duration - minDuration) / (maxDuration - minDuration);
+
+    const red =
+      NODES_MIN_RED + Math.floor((NODES_MAX_RED - NODES_MIN_RED) * percentage);
+    const green =
+      NODES_MAX_GREEN -
+      Math.floor((NODES_MAX_GREEN - NODES_MIN_GREEN) * percentage);
+
+    return `rgba(${red}, ${green}, 0, ${hover ? 0.5 : 0.8})`;
+  };
+
   return (
     <TableContainer component={Paper}>
       <Table>
@@ -118,7 +138,8 @@ export function NodesTable({
               }}
               sx={{
                 cursor: "pointer",
-                "&:hover": { bgcolor: "rgba(0, 0, 0, 0.04)" },
+                bgcolor: getColor(node.totalTiming),
+                "&:hover": { bgcolor: getColor(node.totalTiming, true) },
               }}
             >
               <TableCell>

--- a/components/nodes/index.ts
+++ b/components/nodes/index.ts
@@ -1,0 +1,1 @@
+export * from "./NodesTable";

--- a/components/timeline/CoreProcesses.tsx
+++ b/components/timeline/CoreProcesses.tsx
@@ -2,10 +2,10 @@ import {
   TimelineTiming,
   TimingType,
   TIMELINE_COLORS,
-  TIMELINE_MAX_GREEN,
-  TIMELINE_MAX_RED,
-  TIMELINE_MIN_GREEN,
-  TIMELINE_MIN_RED,
+  MAX_GREEN,
+  MAX_RED,
+  MIN_GREEN,
+  MIN_RED,
 } from "@/lib/types";
 import { Box, Tooltip } from "@mui/material";
 import { ReactElement } from "react";
@@ -39,12 +39,8 @@ export function CoreProcesses({
     const duration = end - start;
     const percentage = (duration - minDuration) / (maxDuration - minDuration);
 
-    const red =
-      TIMELINE_MIN_RED +
-      Math.floor((TIMELINE_MAX_RED - TIMELINE_MIN_RED) * percentage);
-    const green =
-      TIMELINE_MAX_GREEN -
-      Math.floor((TIMELINE_MAX_GREEN - TIMELINE_MIN_GREEN) * percentage);
+    const red = MIN_RED + Math.floor((MAX_RED - MIN_RED) * percentage);
+    const green = MAX_GREEN - Math.floor((MAX_GREEN - MIN_GREEN) * percentage);
 
     return `rgb(${red}, ${green}, 0)`;
   };

--- a/components/timeline/TimelineLegend.tsx
+++ b/components/timeline/TimelineLegend.tsx
@@ -1,9 +1,9 @@
 import {
   TIMELINE_COLORS,
-  TIMELINE_MAX_GREEN,
-  TIMELINE_MAX_RED,
-  TIMELINE_MIN_GREEN,
-  TIMELINE_MIN_RED,
+  MAX_GREEN,
+  MAX_RED,
+  MIN_GREEN,
+  MIN_RED,
 } from "@/lib/types";
 import { Box, Grid2, Typography } from "@mui/material";
 import { ReactElement } from "react";
@@ -39,7 +39,7 @@ export function TimelineLegend({
           borderRadius={4}
           marginX={1}
           sx={{
-            background: `linear-gradient(to right, rgb(${TIMELINE_MIN_RED}, ${TIMELINE_MAX_GREEN}, 0), rgb(${TIMELINE_MAX_RED}, ${TIMELINE_MIN_GREEN}, 0))`,
+            background: `linear-gradient(to right, rgb(${MIN_RED}, ${MAX_GREEN}, 0), rgb(${MAX_RED}, ${MIN_GREEN}, 0))`,
           }}
           position="relative"
         >

--- a/lib/functions/slowestNodes.test.ts
+++ b/lib/functions/slowestNodes.test.ts
@@ -70,7 +70,11 @@ const databaseRetrievals: DatabaseRetrieval[] = [
 describe("getSlowestNodes", () => {
   it("gives nothing when given nothing", () => {
     const result = getSlowestNodes(emptyQueryPlan, 1);
-    expect(result).toEqual([]);
+    expect(result).toEqual({
+      minDuration: 0,
+      maxDuration: 0,
+      processedNodes: [],
+    });
   });
 
   it("gives the slowest node when given one", () => {
@@ -79,18 +83,26 @@ describe("getSlowestNodes", () => {
       1,
     );
 
-    const expected: ProcessedNode[] = [
-      {
-        id: 0,
-        type: "Aggregate",
-        maxTiming: 37,
-        totalTiming: 37,
-        mean: 37,
-        stdDev: 0,
-        parallelCount: 1,
-        pass: "",
-      },
-    ];
+    const expected: {
+      minDuration: number;
+      maxDuration: number;
+      processedNodes: ProcessedNode[];
+    } = {
+      minDuration: 37,
+      maxDuration: 37,
+      processedNodes: [
+        {
+          id: 0,
+          maxTiming: 37,
+          mean: 37,
+          parallelCount: 1,
+          pass: "",
+          stdDev: 0,
+          totalTiming: 37,
+          type: "Aggregate",
+        },
+      ],
+    };
 
     expect(result).toEqual(expected);
   });
@@ -101,18 +113,26 @@ describe("getSlowestNodes", () => {
       1,
     );
 
-    const expected: ProcessedNode[] = [
-      {
-        id: 1,
-        type: "Database",
-        maxTiming: 20,
-        totalTiming: 25,
-        mean: 15,
-        stdDev: 5,
-        parallelCount: 2,
-        pass: "",
-      },
-    ];
+    const expected: {
+      minDuration: number;
+      maxDuration: number;
+      processedNodes: ProcessedNode[];
+    } = {
+      minDuration: 1,
+      maxDuration: 25,
+      processedNodes: [
+        {
+          id: 1,
+          maxTiming: 20,
+          mean: 15,
+          parallelCount: 2,
+          pass: "",
+          stdDev: 5,
+          totalTiming: 25,
+          type: "Database",
+        },
+      ],
+    };
 
     expect(result).toEqual(expected);
   });
@@ -123,28 +143,36 @@ describe("getSlowestNodes", () => {
       2,
     );
 
-    const expected: ProcessedNode[] = [
-      {
-        id: 0,
-        type: "Aggregate",
-        maxTiming: 37,
-        totalTiming: 37,
-        mean: 37,
-        stdDev: 0,
-        parallelCount: 1,
-        pass: "",
-      },
-      {
-        id: 1,
-        type: "Database",
-        maxTiming: 20,
-        totalTiming: 25,
-        mean: 15,
-        stdDev: 5,
-        parallelCount: 2,
-        pass: "",
-      },
-    ];
+    const expected: {
+      minDuration: number;
+      maxDuration: number;
+      processedNodes: ProcessedNode[];
+    } = {
+      maxDuration: 37,
+      minDuration: 1,
+      processedNodes: [
+        {
+          id: 0,
+          maxTiming: 37,
+          mean: 37,
+          parallelCount: 1,
+          pass: "",
+          stdDev: 0,
+          totalTiming: 37,
+          type: "Aggregate",
+        },
+        {
+          id: 1,
+          maxTiming: 20,
+          mean: 15,
+          parallelCount: 2,
+          pass: "",
+          stdDev: 5,
+          totalTiming: 25,
+          type: "Database",
+        },
+      ],
+    };
 
     expect(result).toEqual(expected);
   });

--- a/lib/functions/slowestNodes.ts
+++ b/lib/functions/slowestNodes.ts
@@ -63,7 +63,11 @@ function computeTimingDetails(timingInfo: TimingInfo): {
 export function getSlowestNodes(
   queryPlan: QueryPlan | AggregatedQueryPlan,
   numberOfNodes: number,
-): ProcessedNode[] {
+): {
+  minDuration: number;
+  maxDuration: number;
+  processedNodes: ProcessedNode[];
+} {
   let aggregateRetrievals: AggregatedAggregateRetrieval[];
   let databaseRetrievals: AggregatedDatabaseRetrieval[];
 
@@ -146,7 +150,15 @@ export function getSlowestNodes(
 
   const allNodes: ProcessedNode[] = [...aggregateNodes, ...databaseNodes];
 
-  return allNodes
-    .sort((a, b) => b.totalTiming - a.totalTiming)
-    .slice(0, numberOfNodes);
+  const minDuration = Math.min(...allNodes.map((node) => node.totalTiming));
+
+  const maxDuration = Math.max(...allNodes.map((node) => node.totalTiming));
+
+  return {
+    minDuration,
+    maxDuration,
+    processedNodes: allNodes
+      .sort((a, b) => b.totalTiming - a.totalTiming)
+      .slice(0, numberOfNodes),
+  };
 }

--- a/lib/functions/slowestNodes.ts
+++ b/lib/functions/slowestNodes.ts
@@ -150,9 +150,15 @@ export function getSlowestNodes(
 
   const allNodes: ProcessedNode[] = [...aggregateNodes, ...databaseNodes];
 
-  const minDuration = Math.min(...allNodes.map((node) => node.totalTiming));
+  const minDuration =
+    allNodes.length > 0
+      ? Math.min(...allNodes.map((node) => node.totalTiming))
+      : 0;
 
-  const maxDuration = Math.max(...allNodes.map((node) => node.totalTiming));
+  const maxDuration =
+    allNodes.length > 0
+      ? Math.max(...allNodes.map((node) => node.totalTiming))
+      : 0;
 
   return {
     minDuration,

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -37,7 +37,7 @@ export type Summary = {
   retrievalsTypeCounts: Record<string, number>;
 };
 
-export const NODES_MAX_GREEN: number = 175;
-export const NODES_MIN_GREEN: number = 50;
-export const NODES_MAX_RED: number = 255;
-export const NODES_MIN_RED: number = 0;
+export const MAX_GREEN: number = 175;
+export const MIN_GREEN: number = 50;
+export const MAX_RED: number = 255;
+export const MIN_RED: number = 0;

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -36,3 +36,8 @@ export type Summary = {
   databaseRetrievalsExecutionContextElapsedTimings: Record<string, number>;
   retrievalsTypeCounts: Record<string, number>;
 };
+
+export const NODES_MAX_GREEN: number = 175;
+export const NODES_MIN_GREEN: number = 50;
+export const NODES_MAX_RED: number = 255;
+export const NODES_MIN_RED: number = 0;

--- a/lib/types/timeline.ts
+++ b/lib/types/timeline.ts
@@ -20,8 +20,3 @@ export const TIMELINE_COLORS: Record<string, string> = {
   DatabaseRetrieval: "primary.dark",
   DatabaseRetrievalExecutionContext: "primary.light",
 };
-
-export const TIMELINE_MAX_GREEN: number = 175;
-export const TIMELINE_MIN_GREEN: number = 50;
-export const TIMELINE_MAX_RED: number = 255;
-export const TIMELINE_MIN_RED: number = 0;


### PR DESCRIPTION
# Issue Number:

Closes #152 
_The issue will be automatically closed if merged_

# Description:

Add components in the slowest nodes page
Add a colored legend and colors in the table

# How to test:

Launch the app `yarn dev`
Add a query plan
Go to the “Nodes” page
See the colors in the table (try changing the sorting in the different columns)
