### PR TITLE
Fix issue #168: V1 format now accepted

### DIFF
--- a/app/submit-query/page.tsx
+++ b/app/submit-query/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { FileExporter, FileUploader } from "@/components";
 import { postRequest } from "@/lib/functions";
+import { convertV1toJson } from "@/lib/functions/convertV1ToJson";
 import { getQueryPlan, setQueryPlan, useAppDispatch } from "@/lib/redux";
 import { queryPlansSchema } from "@/lib/types";
 import { CopyAll } from "@mui/icons-material";
@@ -25,6 +26,15 @@ import { useSelector } from "react-redux";
 
 const DEFAULT_URL =
   "https://activepivot-ranch.activeviam.com:6100/activeviam/pivot/rest/v9/cube/query/mdx/queryplan";
+
+function isJsonString(str: string) {
+  try {
+    JSON.parse(str);
+  } catch (e) {
+    return false;
+  }
+  return true;
+}
 
 export default function SubmitQueryPage(): ReactElement {
   const [error, setError] = useState<string | null>(null);
@@ -64,26 +74,47 @@ export default function SubmitQueryPage(): ReactElement {
     }
   };
 
-  const handleManualSubmit = (): void => {
-    try {
-      setError(null);
-      dispatch(setQueryPlan(""));
-      if (!manualQueryPlan.trim()) {
-        setError("Query plan cannot be empty.");
-        return;
+  const handleManualSubmit = async (): Promise<void> => {
+    setError(null);
+    dispatch(setQueryPlan(""));
+    if (!manualQueryPlan.trim()) {
+      setError("Query plan cannot be empty.");
+      return;
+    }
+    if (isJsonString(manualQueryPlan)) {
+      // JSON is valid
+      // We expect the JSON query plan format given by the server
+      try {
+        const parsed = queryPlansSchema.safeParse(JSON.parse(manualQueryPlan));
+        if (!parsed.success) {
+          setError("Failed to parse JSON to query plan schema.");
+          console.error(parsed.error);
+          return;
+        }
+        dispatch(setQueryPlan(parsed.data));
+      } catch {
+        setError("Unexpected error parsing JSON.");
       }
-
-      const parsed = queryPlansSchema.safeParse(JSON.parse(manualQueryPlan));
-
-      if (!parsed.success) {
-        setError("Invalid JSON format in query plan.");
-        console.error(parsed.error);
-        return;
+    } else {
+      // Not a JSON, we try if it is a V1 format
+      try {
+        const convertedV1ToStringArray = JSON.stringify(
+          await convertV1toJson(manualQueryPlan),
+        );
+        const parsed = queryPlansSchema.safeParse(
+          JSON.parse(convertedV1ToStringArray),
+        );
+        if (!parsed.success) {
+          setError("Failed to parse JSON to query plan schema.");
+          console.error(parsed.error);
+          return;
+        }
+        dispatch(setQueryPlan(parsed.data));
+      } catch {
+        setError(
+          "The input doesn't seem to be a JSON format or a valid V1 format",
+        );
       }
-
-      dispatch(setQueryPlan(parsed.data));
-    } catch {
-      setError("Invalid JSON format in query plan.");
     }
   };
 
@@ -200,7 +231,7 @@ export default function SubmitQueryPage(): ReactElement {
                 multiline
                 minRows={6}
                 maxRows={12}
-                placeholder="Enter Query Plan JSON"
+                placeholder="Enter Query Plan : JSON or V1 format"
                 sx={{ width: "100%" }}
                 value={manualQueryPlan}
                 onChange={(e) => setManualQueryPlan(e.target.value)} // Update state

--- a/app/submit-query/page.tsx
+++ b/app/submit-query/page.tsx
@@ -27,10 +27,10 @@ import { useSelector } from "react-redux";
 const DEFAULT_URL =
   "https://activepivot-ranch.activeviam.com:6100/activeviam/pivot/rest/v9/cube/query/mdx/queryplan";
 
-function isJsonString(str: string) {
+function isJsonString(str: string): boolean {
   try {
     JSON.parse(str);
-  } catch (e) {
+  } catch {
     return false;
   }
   return true;


### PR DESCRIPTION
# Issue Number: #168 

Closes #168 
_The issue will be automatically closed if merged_

# Description:

User can now give a query plan on V1 format entering a file or directly text

# How to test:

Launch the app `yarn dev`
Go to page: submit-query
Get a V1 query plan. I suggest copying the one in the `convertV1ToJson.test.ts` an placing it in a file
Test that it is accepted and is correctly analysed by our tool like any query plan
