### PR TITLE
Fixing issue #164: problems when sorting the slowest nodes

### DIFF
--- a/app/nodes/page.tsx
+++ b/app/nodes/page.tsx
@@ -42,12 +42,14 @@ export default function NodesPage(): ReactElement {
       const { minDuration, maxDuration, processedNodes } = getSlowestNodes(
         selectedQueryPlan,
         numberOfNodes,
+        sortColumn,
+        sortOrder,
       );
       setMinDuration(minDuration);
       setMaxDuration(maxDuration);
       setDisplayedNodes(processedNodes);
     }
-  }, [queryPlan, selectedIndex, numberOfNodes]);
+  }, [queryPlan, selectedIndex, numberOfNodes, sortColumn, sortOrder]);
 
   if (!queryPlan || queryPlan.length === 0) {
     return (
@@ -66,14 +68,6 @@ export default function NodesPage(): ReactElement {
     const newOrder = isAsc ? "desc" : "asc";
     setSortOrder(newOrder);
     setSortColumn(column);
-
-    const sortedNodes = [...displayedNodes].sort((a, b) => {
-      if (a[column] < b[column]) return newOrder === "asc" ? -1 : 1;
-      if (a[column] > b[column]) return newOrder === "asc" ? 1 : -1;
-      return 0;
-    });
-
-    setDisplayedNodes(sortedNodes);
   };
 
   const getRetrievalFromNode = (

--- a/lib/functions/slowestNodes.ts
+++ b/lib/functions/slowestNodes.ts
@@ -63,6 +63,8 @@ function computeTimingDetails(timingInfo: TimingInfo): {
 export function getSlowestNodes(
   queryPlan: QueryPlan | AggregatedQueryPlan,
   numberOfNodes: number,
+  sortColumn: keyof ProcessedNode = "totalTiming",
+  sortOrder: "asc" | "desc" = "desc",
 ): {
   minDuration: number;
   maxDuration: number;
@@ -160,11 +162,15 @@ export function getSlowestNodes(
       ? Math.max(...allNodes.map((node) => node.totalTiming))
       : 0;
 
+  allNodes.sort((a, b) => {
+    if (a[sortColumn] < b[sortColumn]) return sortOrder === "asc" ? -1 : 1;
+    if (a[sortColumn] > b[sortColumn]) return sortOrder === "asc" ? 1 : -1;
+    return 0;
+  });
+
   return {
     minDuration,
     maxDuration,
-    processedNodes: allNodes
-      .sort((a, b) => b.totalTiming - a.totalTiming)
-      .slice(0, numberOfNodes),
+    processedNodes: allNodes.slice(0, numberOfNodes),
   };
 }


### PR DESCRIPTION
# Issue Number: 164

Closes #164 

# Description:

Before in the Nodes Page, when sorting by another column, it only sorted the displayed retrievals and not all the retrievals.
Currently, the sort function is checking all the nodes

# How to test:

Launch the app `yarn dev`
Load your query plan
Go to page "Nodes"
Try to change the different column sort
