### PR TITLE
Fix issue #184: Compute on server

### DIFF
--- a/app/api/process-query-plan/route.ts
+++ b/app/api/process-query-plan/route.ts
@@ -1,0 +1,66 @@
+import { convertV1toJson } from "@/lib/functions/convertV1ToJson";
+import { QueryPlan, queryPlansSchema } from "@/lib/types";
+import { NextRequest, NextResponse } from "next/server";
+
+function isJsonString(str: string): boolean {
+  try {
+    JSON.parse(str);
+  } catch {
+    return false;
+  }
+  return true;
+}
+
+export async function POST(
+  req: NextRequest,
+): Promise<NextResponse<{ queryPlan: QueryPlan[] } | { error: string }>> {
+  const body: { queryPlan: string } = await req.json();
+  const { queryPlan } = body;
+
+  if (!queryPlan || !queryPlan.trim())
+    return NextResponse.json(
+      {
+        error: "Query plan cannot be empty.",
+      },
+      { status: 400 },
+    );
+
+  // Try parsing it as JSON first
+  if (isJsonString(queryPlan)) {
+    try {
+      const parsed = queryPlansSchema.safeParse(JSON.parse(queryPlan));
+
+      if (!parsed.success)
+        return NextResponse.json(
+          { error: "Failed to parse JSON to query plan schema." },
+          { status: 400 },
+        );
+
+      return NextResponse.json({ queryPlan: parsed.data });
+    } catch {
+      return NextResponse.json(
+        { error: "Unexpected error parsing JSON." },
+        { status: 400 },
+      );
+    }
+  } else {
+    // If not JSON, attempt V1 format conversion
+    try {
+      const converted = await convertV1toJson(queryPlan);
+      const parsed = queryPlansSchema.safeParse(converted);
+
+      if (!parsed.success)
+        return NextResponse.json(
+          { error: "Failed to parse V1 format to query plan schema." },
+          { status: 400 },
+        );
+
+      return NextResponse.json({ queryPlan: parsed.data });
+    } catch {
+      return NextResponse.json(
+        { error: "The input doesn't seem to be a valid V1 format." },
+        { status: 400 },
+      );
+    }
+  }
+}

--- a/app/api/timeline/route.ts
+++ b/app/api/timeline/route.ts
@@ -1,0 +1,11 @@
+import { buildTimeline } from "@/lib/functions";
+import { QueryPlan, AggregatedQueryPlan, Timeline } from "@/lib/types";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(req: NextRequest): Promise<NextResponse<Timeline>> {
+  const body: { queryPlan: QueryPlan | AggregatedQueryPlan } = await req.json();
+  const { queryPlan } = body;
+
+  const timeline = buildTimeline(queryPlan);
+  return NextResponse.json(timeline);
+}

--- a/lib/functions/buildTimeline.test.ts
+++ b/lib/functions/buildTimeline.test.ts
@@ -80,13 +80,12 @@ describe("buildTimeline", () => {
   });
 
   it("builds a timeline from aggregate retrievals", () => {
-    const result = buildTimeline({ ...emptyQueryPlan, aggregateRetrievals });
+    const result = buildTimeline({
+      ...emptyQueryPlan,
+      aggregateRetrievals,
+    });
 
-    const expected: Timeline & {
-      minDuration: number;
-      maxDuration: number;
-      totalProcesses: number;
-    } = {
+    const expected: Timeline = {
       "0": [
         {
           start: 0,
@@ -114,13 +113,12 @@ describe("buildTimeline", () => {
   });
 
   it("builds a timeline from database retrievals", () => {
-    const result = buildTimeline({ ...emptyQueryPlan, databaseRetrievals });
+    const result = buildTimeline({
+      ...emptyQueryPlan,
+      databaseRetrievals,
+    });
 
-    const expected: Timeline & {
-      minDuration: number;
-      maxDuration: number;
-      totalProcesses: number;
-    } = {
+    const expected: Timeline = {
       "0": [
         {
           start: 8,
@@ -152,11 +150,7 @@ describe("buildTimeline", () => {
       databaseRetrievals,
     });
 
-    const expected: Timeline & {
-      minDuration: number;
-      maxDuration: number;
-      totalProcesses: number;
-    } = {
+    const expected: Timeline = {
       "0": [
         {
           start: 0,
@@ -208,11 +202,7 @@ describe("buildTimeline", () => {
       databaseRetrievals,
     });
 
-    const expected: Timeline & {
-      minDuration: number;
-      maxDuration: number;
-      totalProcesses: number;
-    } = {
+    const expected: Timeline = {
       "0": [
         {
           start: 0,

--- a/lib/functions/buildTimeline.ts
+++ b/lib/functions/buildTimeline.ts
@@ -9,11 +9,7 @@ import {
 
 export function buildTimeline(
   queryPlan: QueryPlan | AggregatedQueryPlan,
-): Timeline & {
-  minDuration: number;
-  maxDuration: number;
-  totalProcesses: number;
-} {
+): Timeline {
   let minDuration: number = Number.MAX_SAFE_INTEGER;
   let maxDuration: number = 0;
   let totalProcesses: number = 0;
@@ -149,7 +145,11 @@ export function buildTimeline(
   // Sort by start time
   filteredTimings.sort((a, b) => a.start - b.start);
 
-  const timeline: Timeline = {};
+  const timeline: Timeline = {
+    minDuration: 0,
+    maxDuration: 0,
+    totalProcesses: 0,
+  };
 
   // Group by core, by trying to fit time intervals into the first available core
   for (const timing of filteredTimings) {

--- a/lib/types/timeline.ts
+++ b/lib/types/timeline.ts
@@ -12,7 +12,11 @@ export type TimelineTiming = {
   pass: string;
 };
 
-export type Timeline = Record<number, TimelineTiming[]>;
+export type Timeline = Record<number, TimelineTiming[]> & {
+  minDuration: number;
+  maxDuration: number;
+  totalProcesses: number;
+};
 
 export const TIMELINE_COLORS: Record<string, string> = {
   AggregateRetrieval: "secondary.dark",


### PR DESCRIPTION
# Issue Number:

Closes #184 
Closes #181 
_The issue will be automatically closed if merged_

# Description:

- Compute timeline on server
- Parse Query Plan on server
- Add loading animations while these

# How to test:

- Launch the app `yarn dev`
- Launch the heavy Query Plan of #160 
- Your computer should not be overloaded

# Other notes:

For consistency I would like to do it for the nodes and summary pages, but they don't have a heavy load. I think it is useless to have such a heavy logic for these pages.

