### PR TITLE
Fix issue #163: Timeline display

### DIFF
--- a/app/timeline/page.tsx
+++ b/app/timeline/page.tsx
@@ -44,7 +44,6 @@ import {
 import { useSelector } from "react-redux";
 
 const MAX_ITEMS = 100;
-const MIN_SCALE = 10;
 const ZOOM_FACTOR = 0.8;
 
 export default function TimelinePage(): ReactElement {
@@ -136,10 +135,7 @@ export default function TimelinePage(): ReactElement {
     if (ctrlKey) {
       event.preventDefault(); // Prevent page scroll
       setScale((prevScale) =>
-        Math.max(
-          MIN_SCALE,
-          Math.min(100, prevScale + (deltaY > 0 ? -ZOOM_FACTOR : ZOOM_FACTOR)),
-        ),
+        Math.min(100, prevScale + (deltaY > 0 ? -ZOOM_FACTOR : ZOOM_FACTOR)),
       );
     }
   }, []);
@@ -234,7 +230,8 @@ export default function TimelinePage(): ReactElement {
         <Slider
           sx={{ width: { xs: "100%", md: "80%" } }}
           value={scale}
-          min={MIN_SCALE}
+          min={containerWidth / maxEnd}
+          max={25} // With this setting, the smaller nodes (1ms) are maximum ~1cm wide when zoomed in
           onChange={(_event, value) => setScale(value as number)}
         />
         <Button

--- a/components/timeline/CoreProcesses.tsx
+++ b/components/timeline/CoreProcesses.tsx
@@ -63,10 +63,11 @@ export const CoreProcesses = memo(
                 Start time: {start}, End time: {end}
               </>
             }
+            sx={{ position: "absolute", left: start * scale }}
           >
             <Box
               component="button" // Behave like a button in a semantic way (cursor, focus, etc.) but no minimum size
-              width={(end - start) * scale}
+              width={`${(end - start) * scale}px`}
               height="100%"
               position="absolute"
               left={start * scale}


### PR DESCRIPTION
# Issue Number:

Closes #163 
_The issue will be automatically closed if merged_

# Description:

- Fix width of small nodes div (when no unit is provided, it's auto `px` but if below 1 convert to percent)
- Better scale: min is now full timeline, max is 25 (enough to see 1ms nodes)

# How to test:

- Launch the app `yarn dev`
- Send a big query with lots of small nodes
- See that the timeline is now correctly displayed
- Test the new scale method
