### PR TITLE
Fix issue #194: Overflow if too much measures

### DIFF
--- a/app/summary/page.tsx
+++ b/app/summary/page.tsx
@@ -535,6 +535,9 @@ export default function SummaryPage(): ReactElement {
                     border: "1px solid #ccc",
                     padding: 2,
                     marginTop: 2,
+                    maxHeight: 407.5,
+                    display: "flex",
+                    flexDirection: "column",
                   }}
                 >
                   <TextField
@@ -546,8 +549,9 @@ export default function SummaryPage(): ReactElement {
                   />
                   <Box
                     sx={{
-                      padding: 2,
                       marginTop: 2,
+                      overflowY: "auto",
+                      flexGrow: 1,
                     }}
                   >
                     <List dense sx={{ marginLeft: 4 }}>


### PR DESCRIPTION
# Issue Number: #194 

Closes #194 
_The issue will be automatically closed if merged_

# Description:

If too much measures, the box will not be extended and there will be a scrolling bar

The maximum size set is equal to the size of the retrievals types box. They will have same size, unless there is really a lot of retrievals types, but it will still be perfectly readable

# How to test:

Launch the app `yarn dev`

Load the big query plan

Go to `submit-query` page

check that the display is good
