### PR TITLE
Fixing issue #198 : refactoring summary page

### DIFF
--- a/app/summary/page.tsx
+++ b/app/summary/page.tsx
@@ -26,9 +26,9 @@ import {
 
 import { ReactElement, useMemo, useState } from "react";
 import { useSelector } from "react-redux";
-import SummarySection from "./ui/SummarySection";
-import TimingList from "./ui/TimingList";
-import TimingPieChart from "./ui/TimingPieChart";
+import { SummarySection } from "./ui/SummarySection";
+import { TimingList } from "./ui/TimingList";
+import { TimingPieChart } from "./ui/TimingPieChart";
 
 export default function SummaryPage(): ReactElement {
   const queryPlan = useSelector(getQueryPlan);

--- a/app/summary/page.tsx
+++ b/app/summary/page.tsx
@@ -144,9 +144,7 @@ export default function SummaryPage(): ReactElement {
                         minHeight: "500px",
                       }}
                     >
-                      <TimingPieChart
-                        data={pieDataElapsedTimings}
-                      ></TimingPieChart>
+                      <TimingPieChart data={pieDataElapsedTimings} />
 
                       <Box sx={{ marginLeft: 2, flex: 1 }}>
                         <Typography
@@ -162,7 +160,7 @@ export default function SummaryPage(): ReactElement {
                         <TimingList
                           data={aggregateRetrievalsElapsedTimings}
                           colorMap={retrievalsColors}
-                        ></TimingList>
+                        />
 
                         <Typography variant="body2" marginLeft={2}>
                           Database retrievals
@@ -170,7 +168,7 @@ export default function SummaryPage(): ReactElement {
                         <TimingList
                           data={databaseRetrievalsElapsedTimings}
                           colorMap={retrievalsColors}
-                        ></TimingList>
+                        />
 
                         <Typography
                           variant="body1"
@@ -186,7 +184,7 @@ export default function SummaryPage(): ReactElement {
                           data={
                             aggregateRetrievalsExecutionContextElapsedTimings
                           }
-                        ></TimingList>
+                        />
 
                         <Typography variant="body2" marginLeft={2}>
                           Database
@@ -195,7 +193,7 @@ export default function SummaryPage(): ReactElement {
                           data={
                             databaseRetrievalsExecutionContextElapsedTimings
                           }
-                        ></TimingList>
+                        />
                       </Box>
                     </Box>
                   ) : (
@@ -210,9 +208,7 @@ export default function SummaryPage(): ReactElement {
                         minHeight: "500px",
                       }}
                     >
-                      <TimingPieChart
-                        data={groupedPieDataElaspedTimings}
-                      ></TimingPieChart>
+                      <TimingPieChart data={groupedPieDataElaspedTimings} />
 
                       <Box sx={{ marginLeft: 2, flex: 1 }}>
                         <Typography
@@ -225,7 +221,7 @@ export default function SummaryPage(): ReactElement {
                         <TimingList
                           data={groupedRetrievalsElapsedTimings}
                           colorMap={GROUP_COLORS}
-                        ></TimingList>
+                        />
 
                         <Typography
                           variant="body1"
@@ -236,7 +232,7 @@ export default function SummaryPage(): ReactElement {
                         </Typography>
                         <TimingList
                           data={groupedRetrievalsExecutionContextElapsedTimings}
-                        ></TimingList>
+                        />
                       </Box>
                     </Box>
                   )}
@@ -320,7 +316,7 @@ export default function SummaryPage(): ReactElement {
                           ? groupedPieDataRetrievalsTypeCounts
                           : pieDataRetrievalsTypeCounts
                       }
-                    ></TimingPieChart>
+                    />
 
                     <Box
                       sx={{
@@ -343,7 +339,7 @@ export default function SummaryPage(): ReactElement {
                         colorMap={
                           isGroupedNumbers ? GROUP_COLORS : retrievalsColors
                         }
-                      ></TimingList>
+                      />
                     </Box>
                   </Box>
                 </Box>
@@ -400,21 +396,21 @@ export default function SummaryPage(): ReactElement {
                     "Data sources or operators that process only a subset of the required data."
                   }
                   data={selectedQueryPlan.querySummary?.partialProviders}
-                ></SummarySection>
+                />
                 <SummarySection
                   title={"Partitioning Count by Type:"}
                   description={
                     "Different types of partitioning, and how much retrievals use each of them. Partitioning can be constant, single or multiple (separated with | )"
                   }
                   data={selectedQueryPlan.querySummary.partitioningCountByType}
-                ></SummarySection>
+                />
                 <SummarySection
                   title={"Partitioning by result size:"}
                   description={
                     "Size of the results given by each type of partioning"
                   }
                   data={selectedQueryPlan.querySummary.resultSizeByPartitioning}
-                ></SummarySection>
+                />
               </Grid2>
             )}
           </Grid2>

--- a/app/summary/page.tsx
+++ b/app/summary/page.tsx
@@ -28,6 +28,7 @@ import {
 import { ReactElement, useMemo, useState } from "react";
 import { useSelector } from "react-redux";
 import { PieChart, Pie, Cell, ResponsiveContainer } from "recharts";
+import TimingPieChart from "./ui/TimingPieChart";
 
 export default function SummaryPage(): ReactElement {
   const queryPlan = useSelector(getQueryPlan);
@@ -143,23 +144,9 @@ export default function SummaryPage(): ReactElement {
                         minHeight: "500px",
                       }}
                     >
-                      <ResponsiveContainer width={250} height={250}>
-                        <PieChart>
-                          <Pie
-                            data={pieDataElapsedTimings}
-                            dataKey="value"
-                            nameKey="name"
-                            cx="50%"
-                            cy="50%"
-                            outerRadius={100}
-                            isAnimationActive={false}
-                          >
-                            {pieDataElapsedTimings.map((entry) => (
-                              <Cell key={entry.name} fill={entry.fill} />
-                            ))}
-                          </Pie>
-                        </PieChart>
-                      </ResponsiveContainer>
+                      <TimingPieChart
+                        data={pieDataElapsedTimings}
+                      ></TimingPieChart>
 
                       <Box sx={{ marginLeft: 2, flex: 1 }}>
                         <Typography
@@ -223,23 +210,9 @@ export default function SummaryPage(): ReactElement {
                         minHeight: "500px",
                       }}
                     >
-                      <ResponsiveContainer width={250} height={250}>
-                        <PieChart>
-                          <Pie
-                            data={groupedPieDataElaspedTimings}
-                            dataKey="value"
-                            nameKey="name"
-                            cx="50%"
-                            cy="50%"
-                            outerRadius={100}
-                            isAnimationActive={false}
-                          >
-                            {groupedPieDataElaspedTimings.map((entry) => (
-                              <Cell key={entry.name} fill={entry.fill} />
-                            ))}
-                          </Pie>
-                        </PieChart>
-                      </ResponsiveContainer>
+                      <TimingPieChart
+                        data={groupedPieDataElaspedTimings}
+                      ></TimingPieChart>
 
                       <Box sx={{ marginLeft: 2, flex: 1 }}>
                         <Typography
@@ -341,30 +314,13 @@ export default function SummaryPage(): ReactElement {
                       overflow: "hidden",
                     }}
                   >
-                    <ResponsiveContainer width={250} height={250}>
-                      <PieChart>
-                        <Pie
-                          data={
-                            isGroupedNumbers
-                              ? groupedPieDataRetrievalsTypeCounts
-                              : pieDataRetrievalsTypeCounts
-                          }
-                          dataKey="value"
-                          nameKey="name"
-                          cx="50%"
-                          cy="50%"
-                          outerRadius={100}
-                          isAnimationActive={false}
-                        >
-                          {(isGroupedNumbers
-                            ? groupedPieDataRetrievalsTypeCounts
-                            : pieDataRetrievalsTypeCounts
-                          ).map((entry) => (
-                            <Cell key={entry.name} fill={entry.fill} />
-                          ))}
-                        </Pie>
-                      </PieChart>
-                    </ResponsiveContainer>
+                    <TimingPieChart
+                      data={
+                        isGroupedNumbers
+                          ? groupedPieDataRetrievalsTypeCounts
+                          : pieDataRetrievalsTypeCounts
+                      }
+                    ></TimingPieChart>
 
                     <Box
                       sx={{

--- a/app/summary/page.tsx
+++ b/app/summary/page.tsx
@@ -9,6 +9,7 @@ import {
 import { getQueryPlan, getSelectedIndex } from "@/lib/redux";
 import { AggregatedQueryPlan, emptyQueryPlan, QueryPlan } from "@/lib/types";
 import InfoIcon from "@mui/icons-material/Info";
+import TimingList from "./ui/TimingList";
 import {
   Card,
   CardContent,
@@ -171,47 +172,18 @@ export default function SummaryPage(): ReactElement {
                         <Typography variant="body2" marginLeft={2}>
                           Aggregate retrievals
                         </Typography>
-                        <List dense sx={{ marginLeft: 4 }}>
-                          {Object.entries(aggregateRetrievalsElapsedTimings)
-                            .sort((a, b) => b[1] - a[1])
-                            .map(([key, value]) => (
-                              <ListItem key={key} disablePadding>
-                                <Box
-                                  sx={{
-                                    width: 12,
-                                    height: 12,
-                                    backgroundColor: retrievalsColors[key],
-                                    marginRight: 1,
-                                  }}
-                                />
-                                <ListItemText
-                                  primary={`${key} : ${value} ms`}
-                                />
-                              </ListItem>
-                            ))}
-                        </List>
+                        <TimingList
+                          data={aggregateRetrievalsElapsedTimings}
+                          colorMap={retrievalsColors}
+                        ></TimingList>
+
                         <Typography variant="body2" marginLeft={2}>
                           Database retrievals
                         </Typography>
-                        <List dense sx={{ marginLeft: 4 }}>
-                          {Object.entries(databaseRetrievalsElapsedTimings)
-                            .sort((a, b) => b[1] - a[1])
-                            .map(([key, value]) => (
-                              <ListItem key={key} disablePadding>
-                                <Box
-                                  sx={{
-                                    width: 12,
-                                    height: 12,
-                                    backgroundColor: retrievalsColors[key],
-                                    marginRight: 1,
-                                  }}
-                                />
-                                <ListItemText
-                                  primary={`${key} : ${value} ms`}
-                                />
-                              </ListItem>
-                            ))}
-                        </List>
+                        <TimingList
+                          data={databaseRetrievalsElapsedTimings}
+                          colorMap={retrievalsColors}
+                        ></TimingList>
 
                         <Typography
                           variant="body1"
@@ -223,49 +195,20 @@ export default function SummaryPage(): ReactElement {
                         <Typography variant="body2" marginLeft={2}>
                           Aggregate
                         </Typography>
-                        <List dense sx={{ marginLeft: 4 }}>
-                          {Object.entries(
-                            aggregateRetrievalsExecutionContextElapsedTimings,
-                          )
-                            .sort((a, b) => b[1] - a[1])
-                            .map(([key, value]) => (
-                              <ListItem key={key} disablePadding>
-                                <Box
-                                  sx={{
-                                    width: 12,
-                                    height: 12,
-                                    marginRight: 1,
-                                  }}
-                                />
-                                <ListItemText
-                                  primary={`${key} : ${value} ms`}
-                                />
-                              </ListItem>
-                            ))}
-                        </List>
+                        <TimingList
+                          data={
+                            aggregateRetrievalsExecutionContextElapsedTimings
+                          }
+                        ></TimingList>
+
                         <Typography variant="body2" marginLeft={2}>
                           Database
                         </Typography>
-                        <List dense sx={{ marginLeft: 4 }}>
-                          {Object.entries(
-                            databaseRetrievalsExecutionContextElapsedTimings,
-                          )
-                            .sort((a, b) => b[1] - a[1])
-                            .map(([key, value]) => (
-                              <ListItem key={key} disablePadding>
-                                <Box
-                                  sx={{
-                                    width: 12,
-                                    height: 12,
-                                    marginRight: 1,
-                                  }}
-                                />
-                                <ListItemText
-                                  primary={`${key} : ${value} ms`}
-                                />
-                              </ListItem>
-                            ))}
-                        </List>
+                        <TimingList
+                          data={
+                            databaseRetrievalsExecutionContextElapsedTimings
+                          }
+                        ></TimingList>
                       </Box>
                     </Box>
                   ) : (
@@ -306,25 +249,10 @@ export default function SummaryPage(): ReactElement {
                         >
                           Elapsed timings
                         </Typography>
-                        <List dense sx={{ marginLeft: 2 }}>
-                          {Object.entries(groupedRetrievalsElapsedTimings)
-                            .sort((a, b) => b[1] - a[1])
-                            .map(([key, value]) => (
-                              <ListItem key={key} disablePadding>
-                                <Box
-                                  sx={{
-                                    width: 12,
-                                    height: 12,
-                                    backgroundColor: GROUP_COLORS[key],
-                                    marginRight: 1,
-                                  }}
-                                />
-                                <ListItemText
-                                  primary={`${key} : ${value} ms`}
-                                />
-                              </ListItem>
-                            ))}
-                        </List>
+                        <TimingList
+                          data={groupedRetrievalsElapsedTimings}
+                          colorMap={GROUP_COLORS}
+                        ></TimingList>
 
                         <Typography
                           variant="body1"
@@ -333,26 +261,9 @@ export default function SummaryPage(): ReactElement {
                         >
                           Elapsed timings (execution context)
                         </Typography>
-                        <List dense sx={{ marginLeft: 2 }}>
-                          {Object.entries(
-                            groupedRetrievalsExecutionContextElapsedTimings,
-                          )
-                            .sort((a, b) => b[1] - a[1])
-                            .map(([key, value]) => (
-                              <ListItem key={key} disablePadding>
-                                <Box
-                                  sx={{
-                                    width: 12,
-                                    height: 12,
-                                    marginRight: 1,
-                                  }}
-                                />
-                                <ListItemText
-                                  primary={`${key} : ${value} ms`}
-                                />
-                              </ListItem>
-                            ))}
-                        </List>
+                        <TimingList
+                          data={groupedRetrievalsExecutionContextElapsedTimings}
+                        ></TimingList>
                       </Box>
                     </Box>
                   )}
@@ -467,36 +378,16 @@ export default function SummaryPage(): ReactElement {
                         Retrievals (
                         {selectedQueryPlan.querySummary.totalRetrievals}) :
                       </Typography>
-
-                      <List
-                        dense
-                        sx={{
-                          marginLeft: 2,
-                          overflowY: "auto",
-                          flex: 1,
-                        }}
-                      >
-                        {(isGroupedNumbers
-                          ? Object.entries(groupedRetrievalsTypeCounts)
-                          : Object.entries(retrievalsTypeCounts)
-                        )
-                          .sort((a, b) => b[1] - a[1])
-                          .map(([key, value]) => (
-                            <ListItem key={key} disablePadding>
-                              <Box
-                                sx={{
-                                  width: 12,
-                                  height: 12,
-                                  backgroundColor: isGroupedNumbers
-                                    ? GROUP_COLORS[key]
-                                    : retrievalsColors[key],
-                                  marginRight: 1,
-                                }}
-                              />
-                              <ListItemText primary={`${key} : ${value}`} />
-                            </ListItem>
-                          ))}
-                      </List>
+                      <TimingList
+                        data={
+                          isGroupedNumbers
+                            ? groupedRetrievalsTypeCounts
+                            : retrievalsTypeCounts
+                        }
+                        colorMap={
+                          isGroupedNumbers ? GROUP_COLORS : retrievalsColors
+                        }
+                      ></TimingList>
                     </Box>
                   </Box>
                 </Box>

--- a/app/summary/page.tsx
+++ b/app/summary/page.tsx
@@ -9,7 +9,6 @@ import {
 import { getQueryPlan, getSelectedIndex } from "@/lib/redux";
 import { AggregatedQueryPlan, emptyQueryPlan, QueryPlan } from "@/lib/types";
 import InfoIcon from "@mui/icons-material/Info";
-import TimingList from "./ui/TimingList";
 import {
   Card,
   CardContent,
@@ -27,9 +26,9 @@ import {
 
 import { ReactElement, useMemo, useState } from "react";
 import { useSelector } from "react-redux";
-import { PieChart, Pie, Cell, ResponsiveContainer } from "recharts";
-import TimingPieChart from "./ui/TimingPieChart";
 import SummarySection from "./ui/SummarySection";
+import TimingList from "./ui/TimingList";
+import TimingPieChart from "./ui/TimingPieChart";
 
 export default function SummaryPage(): ReactElement {
   const queryPlan = useSelector(getQueryPlan);

--- a/app/summary/page.tsx
+++ b/app/summary/page.tsx
@@ -29,6 +29,7 @@ import { ReactElement, useMemo, useState } from "react";
 import { useSelector } from "react-redux";
 import { PieChart, Pie, Cell, ResponsiveContainer } from "recharts";
 import TimingPieChart from "./ui/TimingPieChart";
+import SummarySection from "./ui/SummarySection";
 
 export default function SummaryPage(): ReactElement {
   const queryPlan = useSelector(getQueryPlan);
@@ -394,102 +395,27 @@ export default function SummaryPage(): ReactElement {
             </Grid2>
             {selectedIndex !== -1 && (
               <Grid2 container padding={1} spacing={2} justifyContent="center">
-                <Grid2 padding={1} spacing={1}>
-                  <Box
-                    sx={{
-                      border: "1px solid #ccc",
-                      padding: 2,
-                      marginTop: 2,
-                    }}
-                  >
-                    <Box display="flex" alignItems="center" gap={1}>
-                      <Typography variant="body1" fontWeight="bold">
-                        Partial Providers (
-                        {selectedQueryPlan.querySummary?.partialProviders
-                          ?.length || 0}
-                        ) :
-                      </Typography>
-                      <Tooltip title="Data sources or operators that process only a subset of the required data.">
-                        <IconButton size="small" style={{ marginLeft: 8 }}>
-                          <InfoIcon fontSize="small" />
-                        </IconButton>
-                      </Tooltip>
-                    </Box>
-                    {selectedQueryPlan.querySummary?.partialProviders ? (
-                      <List dense sx={{ marginLeft: 4 }}>
-                        {Object.entries(
-                          selectedQueryPlan.querySummary.partialProviders,
-                        ).map(([key, value]) => (
-                          <ListItem key={key} disablePadding>
-                            <ListItemText primary={value} />
-                          </ListItem>
-                        ))}
-                      </List>
-                    ) : (
-                      <Typography variant="body2" sx={{ marginLeft: 4 }}>
-                        No partial providers available.
-                      </Typography>
-                    )}
-                  </Box>
-                </Grid2>
-                <Grid2 padding={1} spacing={1}>
-                  <Box
-                    sx={{
-                      border: "1px solid #ccc",
-                      padding: 2,
-                      marginTop: 2,
-                    }}
-                  >
-                    <Box display="flex" alignItems="center" gap={1}>
-                      <Typography variant="body1" fontWeight="bold">
-                        Partitioning Count by Type:
-                      </Typography>
-                      <Tooltip title="Different types of partitioning, and how much retrievals use each of them. Partitioning can be constant, single or multiple (separated with | )">
-                        <IconButton size="small">
-                          <InfoIcon fontSize="small" />
-                        </IconButton>
-                      </Tooltip>
-                    </Box>
-                    <List dense sx={{ marginLeft: 4 }}>
-                      {Object.entries(
-                        selectedQueryPlan.querySummary.partitioningCountByType,
-                      ).map(([key, value]) => (
-                        <ListItem key={key} disablePadding>
-                          <ListItemText primary={`${key} : ${value}`} />
-                        </ListItem>
-                      ))}
-                    </List>
-                  </Box>
-                </Grid2>
-                <Grid2 padding={1} spacing={1}>
-                  <Box
-                    sx={{
-                      border: "1px solid #ccc",
-                      padding: 2,
-                      marginTop: 2,
-                    }}
-                  >
-                    <Box display="flex" alignItems="center" gap={1}>
-                      <Typography variant="body1" fontWeight="bold">
-                        Partitioning by result size:
-                      </Typography>
-                      <Tooltip title="Size of the results given by each type of partioning">
-                        <IconButton size="small" style={{ marginLeft: 8 }}>
-                          <InfoIcon fontSize="small" />
-                        </IconButton>
-                      </Tooltip>
-                    </Box>
-                    <List dense sx={{ marginLeft: 4 }}>
-                      {Object.entries(
-                        selectedQueryPlan.querySummary.resultSizeByPartitioning,
-                      ).map(([key, value]) => (
-                        <ListItem key={key} disablePadding>
-                          <ListItemText primary={`${key} : ${value}`} />
-                        </ListItem>
-                      ))}
-                    </List>
-                  </Box>
-                </Grid2>
+                <SummarySection
+                  title={`Partial Providers (${selectedQueryPlan.querySummary?.partialProviders?.length || 0}) :`}
+                  description={
+                    "Data sources or operators that process only a subset of the required data."
+                  }
+                  data={selectedQueryPlan.querySummary?.partialProviders}
+                ></SummarySection>
+                <SummarySection
+                  title={"Partitioning Count by Type:"}
+                  description={
+                    "Different types of partitioning, and how much retrievals use each of them. Partitioning can be constant, single or multiple (separated with | )"
+                  }
+                  data={selectedQueryPlan.querySummary.partitioningCountByType}
+                ></SummarySection>
+                <SummarySection
+                  title={"Partitioning by result size:"}
+                  description={
+                    "Size of the results given by each type of partioning"
+                  }
+                  data={selectedQueryPlan.querySummary.resultSizeByPartitioning}
+                ></SummarySection>
               </Grid2>
             )}
           </Grid2>

--- a/app/summary/ui/SummarySection.tsx
+++ b/app/summary/ui/SummarySection.tsx
@@ -1,0 +1,61 @@
+import {
+  Grid2,
+  Box,
+  Typography,
+  List,
+  ListItem,
+  ListItemText,
+  IconButton,
+  Tooltip,
+} from "@mui/material";
+import InfoIcon from "@mui/icons-material/Info";
+
+interface SummarySectionProps {
+  title: string;
+  description: string;
+  data: string[] | Record<string, number>;
+}
+
+const SummarySection: React.FC<SummarySectionProps> = ({
+  title,
+  description,
+  data,
+}) => {
+  return (
+    <Grid2 padding={1} spacing={1}>
+      <Box
+        sx={{
+          border: "1px solid #ccc",
+          padding: 2,
+          marginTop: 2,
+        }}
+      >
+        <Box display="flex" alignItems="center" gap={1}>
+          <Typography variant="body1" fontWeight="bold">
+            {title}
+          </Typography>
+          <Tooltip title={description}>
+            <IconButton size="small" style={{ marginLeft: 8 }}>
+              <InfoIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+        </Box>
+        <List dense sx={{ marginLeft: 4 }}>
+          {Array.isArray(data)
+            ? data.map((item, index) => (
+                <ListItem key={index} disablePadding>
+                  <ListItemText primary={item} />
+                </ListItem>
+              ))
+            : Object.entries(data).map(([key, value]) => (
+                <ListItem key={key} disablePadding>
+                  <ListItemText primary={`${key}: ${value}`} />
+                </ListItem>
+              ))}
+        </List>
+      </Box>
+    </Grid2>
+  );
+};
+
+export default SummarySection;

--- a/app/summary/ui/SummarySection.tsx
+++ b/app/summary/ui/SummarySection.tsx
@@ -9,18 +9,19 @@ import {
   IconButton,
   Tooltip,
 } from "@mui/material";
+import { ReactElement } from "react";
 
-interface SummarySectionProps {
+type SummarySectionProps = {
   title: string;
   description: string;
   data: string[] | Record<string, number>;
-}
+};
 
-const SummarySection: React.FC<SummarySectionProps> = ({
+export function SummarySection({
   title,
   description,
   data,
-}) => {
+}: SummarySectionProps): ReactElement {
   return (
     <Grid2 padding={1} spacing={1}>
       <Box
@@ -56,6 +57,4 @@ const SummarySection: React.FC<SummarySectionProps> = ({
       </Box>
     </Grid2>
   );
-};
-
-export default SummarySection;
+}

--- a/app/summary/ui/SummarySection.tsx
+++ b/app/summary/ui/SummarySection.tsx
@@ -1,3 +1,4 @@
+import InfoIcon from "@mui/icons-material/Info";
 import {
   Grid2,
   Box,
@@ -8,7 +9,6 @@ import {
   IconButton,
   Tooltip,
 } from "@mui/material";
-import InfoIcon from "@mui/icons-material/Info";
 
 interface SummarySectionProps {
   title: string;

--- a/app/summary/ui/TimingList.tsx
+++ b/app/summary/ui/TimingList.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { Box, List, ListItem, ListItemText } from "@mui/material";
+
+interface TimingListProps {
+  data: Record<string, number>;
+  colorMap?: Record<string, string>; // color not mandatory
+}
+
+const TimingList: React.FC<TimingListProps> = ({ data, colorMap }) => {
+  return (
+    <List dense sx={{ marginLeft: 4 }}>
+      {Object.entries(data)
+        .sort((a, b) => b[1] - a[1])
+        .map(([key, value]) => (
+          <ListItem key={key} disablePadding>
+            <Box
+              sx={{
+                width: 12,
+                height: 12,
+                backgroundColor: colorMap?.[key] || "transparent",
+                marginRight: 1,
+              }}
+            />
+            <ListItemText primary={`${key} : ${value} ms`} />
+          </ListItem>
+        ))}
+    </List>
+  );
+};
+
+export default TimingList;

--- a/app/summary/ui/TimingList.tsx
+++ b/app/summary/ui/TimingList.tsx
@@ -8,7 +8,14 @@ type TimingListProps = {
 
 export function TimingList({ data, colorMap }: TimingListProps): ReactElement {
   return (
-    <List dense sx={{ marginLeft: 4 }}>
+    <List
+      dense
+      sx={{
+        marginLeft: 2,
+        overflowY: "auto",
+        flex: 1,
+      }}
+    >
       {Object.entries(data)
         .sort((a, b) => b[1] - a[1])
         .map(([key, value]) => (

--- a/app/summary/ui/TimingList.tsx
+++ b/app/summary/ui/TimingList.tsx
@@ -1,5 +1,5 @@
-import React from "react";
 import { Box, List, ListItem, ListItemText } from "@mui/material";
+import React from "react";
 
 interface TimingListProps {
   data: Record<string, number>;

--- a/app/summary/ui/TimingList.tsx
+++ b/app/summary/ui/TimingList.tsx
@@ -1,12 +1,12 @@
 import { Box, List, ListItem, ListItemText } from "@mui/material";
-import React from "react";
+import { ReactElement } from "react";
 
-interface TimingListProps {
+type TimingListProps = {
   data: Record<string, number>;
-  colorMap?: Record<string, string>; // color not mandatory
-}
+  colorMap?: Record<string, string>;
+};
 
-const TimingList: React.FC<TimingListProps> = ({ data, colorMap }) => {
+export function TimingList({ data, colorMap }: TimingListProps): ReactElement {
   return (
     <List dense sx={{ marginLeft: 4 }}>
       {Object.entries(data)
@@ -26,6 +26,4 @@ const TimingList: React.FC<TimingListProps> = ({ data, colorMap }) => {
         ))}
     </List>
   );
-};
-
-export default TimingList;
+}

--- a/app/summary/ui/TimingPieChart.tsx
+++ b/app/summary/ui/TimingPieChart.tsx
@@ -1,0 +1,31 @@
+import { PiePartData } from "@/lib/types";
+import React from "react";
+import { ResponsiveContainer, PieChart, Pie, Cell } from "recharts";
+
+interface TimingPieChartProps {
+  data: PiePartData[];
+}
+
+const TimingPieChart: React.FC<TimingPieChartProps> = ({ data }) => {
+  return (
+    <ResponsiveContainer width={250} height={250}>
+      <PieChart>
+        <Pie
+          data={data}
+          dataKey="value"
+          nameKey="name"
+          cx="50%"
+          cy="50%"
+          outerRadius={100}
+          isAnimationActive={false}
+        >
+          {data.map((entry) => (
+            <Cell key={entry.name} fill={entry.fill} />
+          ))}
+        </Pie>
+      </PieChart>
+    </ResponsiveContainer>
+  );
+};
+
+export default TimingPieChart;

--- a/app/summary/ui/TimingPieChart.tsx
+++ b/app/summary/ui/TimingPieChart.tsx
@@ -1,12 +1,12 @@
 import { PiePartData } from "@/lib/types";
-import React from "react";
+import { ReactElement } from "react";
 import { ResponsiveContainer, PieChart, Pie, Cell } from "recharts";
 
-interface TimingPieChartProps {
+type TimingPieChartProps = {
   data: PiePartData[];
-}
+};
 
-const TimingPieChart: React.FC<TimingPieChartProps> = ({ data }) => {
+export function TimingPieChart({ data }: TimingPieChartProps): ReactElement {
   return (
     <ResponsiveContainer width={250} height={250}>
       <PieChart>
@@ -26,6 +26,4 @@ const TimingPieChart: React.FC<TimingPieChartProps> = ({ data }) => {
       </PieChart>
     </ResponsiveContainer>
   );
-};
-
-export default TimingPieChart;
+}

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -12,7 +12,7 @@ export type ProcessedNode = {
   pass: string;
 };
 
-type PiePartData = {
+export type PiePartData = {
   name: string;
   value: number;
   fill: string;


### PR DESCRIPTION
# Issue Number: #198 

Closes #198
_The issue will be automatically closed if merged_
Contributes to #199 


# Description:

Refactoring summary page, adding components and avoiding repeats

# How to test:

Launch the app `yarn dev`
Load a query plan
Go to page: `summary`
Check that the page behaves exactly like main
