### PR TITLE
Fixing bug : "ms" unit displaying when not needed

### DIFF
--- a/app/summary/page.tsx
+++ b/app/summary/page.tsx
@@ -160,6 +160,7 @@ export default function SummaryPage(): ReactElement {
                         <TimingList
                           data={aggregateRetrievalsElapsedTimings}
                           colorMap={retrievalsColors}
+                          unit="ms"
                         />
 
                         <Typography variant="body2" marginLeft={2}>
@@ -168,6 +169,7 @@ export default function SummaryPage(): ReactElement {
                         <TimingList
                           data={databaseRetrievalsElapsedTimings}
                           colorMap={retrievalsColors}
+                          unit="ms"
                         />
 
                         <Typography
@@ -184,6 +186,7 @@ export default function SummaryPage(): ReactElement {
                           data={
                             aggregateRetrievalsExecutionContextElapsedTimings
                           }
+                          unit="ms"
                         />
 
                         <Typography variant="body2" marginLeft={2}>
@@ -193,6 +196,7 @@ export default function SummaryPage(): ReactElement {
                           data={
                             databaseRetrievalsExecutionContextElapsedTimings
                           }
+                          unit="ms"
                         />
                       </Box>
                     </Box>
@@ -221,6 +225,7 @@ export default function SummaryPage(): ReactElement {
                         <TimingList
                           data={groupedRetrievalsElapsedTimings}
                           colorMap={GROUP_COLORS}
+                          unit="ms"
                         />
 
                         <Typography
@@ -232,6 +237,7 @@ export default function SummaryPage(): ReactElement {
                         </Typography>
                         <TimingList
                           data={groupedRetrievalsExecutionContextElapsedTimings}
+                          unit="ms"
                         />
                       </Box>
                     </Box>

--- a/app/summary/ui/TimingList.tsx
+++ b/app/summary/ui/TimingList.tsx
@@ -4,9 +4,14 @@ import { ReactElement } from "react";
 type TimingListProps = {
   data: Record<string, number>;
   colorMap?: Record<string, string>;
+  unit?: string;
 };
 
-export function TimingList({ data, colorMap }: TimingListProps): ReactElement {
+export function TimingList({
+  data,
+  colorMap,
+  unit = "", // by default no unit is shown
+}: TimingListProps): ReactElement {
   return (
     <List
       dense
@@ -28,7 +33,7 @@ export function TimingList({ data, colorMap }: TimingListProps): ReactElement {
                 marginRight: 1,
               }}
             />
-            <ListItemText primary={`${key} : ${value} ms`} />
+            <ListItemText primary={`${key} : ${value} ${unit}`} />
           </ListItem>
         ))}
     </List>


### PR DESCRIPTION
# Description:

"ms" was displaying for the number of retrievals, that has no unit.

# How to test:

Launch the app `yarn dev`
Load a query plan
Go to page: summary
Check that the display is correct
